### PR TITLE
Redirect logs to /dev/null

### DIFF
--- a/pkg/controller/keystone/keystone_config.go
+++ b/pkg/controller/keystone/keystone_config.go
@@ -61,6 +61,10 @@ const keystoneKollaServiceConfig = `{
     ],
     "permissions": [
         {
+            "path": "/var/log/kolla",
+            "owner": "keystone:kolla"
+        },
+        {
             "path": "/etc/keystone/fernet-keys",
             "owner": "keystone:keystone",
             "perm": "0770"
@@ -77,7 +81,6 @@ var keystoneConf = template.Must(template.New("").Parse(`
 [DEFAULT]
 debug = False
 transport_url = rabbit://guest:guest@{{ .RabbitMQServer }}//
-log_file = /dev/null
 use_stderr = True
 
 [oslo_middleware]
@@ -132,8 +135,8 @@ TraceEnable off
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
-    ErrorLog "/dev/null"
     LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
-    CustomLog "/dev/null" logformat
+    ErrorLog "|/usr/sbin/rotatelogs /var/log/kolla/keystone/keystone-apache-public-error.log"
+    CustomLog "|/usr/sbin/rotatelogs /var/log/kolla/keystone/keystone-apache-public-access.log 604800" logformat
 </VirtualHost>
 `))

--- a/pkg/controller/keystone/keystone_config_fernet.go
+++ b/pkg/controller/keystone/keystone_config_fernet.go
@@ -87,7 +87,6 @@ var keystoneFernetConfig = template.Must(template.New("").Parse(`
 [DEFAULT]
 debug = False
 transport_url = rabbit://guest:guest@{{ .RabbitMQServer }}//
-log_file = /dev/null
 use_stderr = True
 
 [oslo_middleware]

--- a/pkg/controller/keystone/keystone_config_init.go
+++ b/pkg/controller/keystone/keystone_config_init.go
@@ -47,6 +47,10 @@ const keystoneInitKollaServiceConfig = `{
     ],
     "permissions": [
         {
+            "path": "/var/log/kolla",
+            "owner": "keystone:kolla"
+        },
+        {
             "path": "/etc/keystone/fernet-keys",
             "owner": "keystone:keystone",
             "perm": "0770"

--- a/pkg/controller/keystone/keystone_config_test.go
+++ b/pkg/controller/keystone/keystone_config_test.go
@@ -32,6 +32,10 @@ const expectedKeystoneKollaServiceConfig = `{
     ],
     "permissions": [
         {
+            "path": "/var/log/kolla",
+            "owner": "keystone:kolla"
+        },
+        {
             "path": "/etc/keystone/fernet-keys",
             "owner": "keystone:keystone",
             "perm": "0770"
@@ -95,7 +99,6 @@ const expectedKeystoneConfig = `
 [DEFAULT]
 debug = False
 transport_url = rabbit://guest:guest@localhost:5672//
-log_file = /dev/null
 use_stderr = True
 
 [oslo_middleware]
@@ -150,9 +153,9 @@ TraceEnable off
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
-    ErrorLog "/dev/null"
     LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
-    CustomLog "/dev/null" logformat
+    ErrorLog "|/usr/sbin/rotatelogs /var/log/kolla/keystone/keystone-apache-public-error.log"
+    CustomLog "|/usr/sbin/rotatelogs /var/log/kolla/keystone/keystone-apache-public-access.log 604800" logformat
 </VirtualHost>
 `
 
@@ -286,6 +289,10 @@ const expectedKeystoneInitKollaServiceConfig = `{
 		}
     ],
     "permissions": [
+        {
+            "path": "/var/log/kolla",
+            "owner": "keystone:kolla"
+        },
         {
             "path": "/etc/keystone/fernet-keys",
             "owner": "keystone:keystone",


### PR DESCRIPTION
All swift* containers log by UDP to another container, so  there is no need to care about their logs. Keystone config has an option to specify log file and it'll be forwarded to /dev/null