### PR TITLE
Dump pods in e2e tests

### DIFF
--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -96,7 +96,7 @@ func ManagerCluster(t *testing.T) {
 	t.Parallel()
 	f := test.Global
 	ctx := test.NewTestCtx(t)
-	defer func() { logger.DumpPods(t, f.Client); ctx.Cleanup() }()
+	defer func() { logger.DumpPods(t, ctx, f.Client); ctx.Cleanup() }()
 
 	if err := test.AddToFrameworkScheme(v1alpha1.SchemeBuilder.AddToScheme, &v1alpha1.ManagerList{}); err != nil {
 		t.Fatalf("Failed to add framework scheme: %v", err)
@@ -261,7 +261,7 @@ func getManager(namespace string, replicas int32, hostNetwork bool, versionMap m
 							Containers: map[string]*v1alpha1.Container{
 								"api":               &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-api:" + versionMap["config"]},
 								"devicemanager":     &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-devicemgr:dev-5"}, // Using custom dev version until required changes are merged upstream
-								"dnsmasq":           &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-dnsmasq:dev"},   // Using custom dev version until required changes are merged upstream
+								"dnsmasq":           &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-dnsmasq:dev"},     // Using custom dev version until required changes are merged upstream
 								"schematransformer": &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-schema:" + versionMap["config"]},
 								"servicemonitor":    &v1alpha1.Container{Image: "registry:5000/contrail-controller-config-svcmonitor:" + versionMap["config"]},
 								"analyticsapi":      &v1alpha1.Container{Image: "registry:5000/contrail-analytics-api:" + versionMap["config"]},
@@ -335,7 +335,7 @@ func RabbitmqCluster(t *testing.T) {
 	t.Parallel()
 	f := test.Global
 	ctx := test.NewTestCtx(t)
-	defer func() { logger.DumpPods(t, f.Client); ctx.Cleanup() }()
+	defer func() { logger.DumpPods(t, ctx, f.Client); ctx.Cleanup() }()
 	err := ctx.InitializeClusterResources(&test.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)

--- a/test/e2e/openstack_test.go
+++ b/test/e2e/openstack_test.go
@@ -22,7 +22,7 @@ import (
 func TestOpenstackServices(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	f := test.Global
-	defer func() { logger.DumpPods(t, f.Client); ctx.Cleanup() }()
+	defer func() { logger.DumpPods(t, ctx, f.Client); ctx.Cleanup() }()
 
 	if err := test.AddToFrameworkScheme(contrail.SchemeBuilder.AddToScheme, &contrail.ManagerList{}); err != nil {
 		t.Fatalf("Failed to add framework scheme: %v", err)


### PR DESCRIPTION
Example logs (this will be so verbose only if something fails)
```Pods statuses at the end of the test
NAME                                STATUS
cassandra1-cassandra-statefulset-0  Running
config1-config-statefulset-0        Pending
rabbitmq1-rabbitmq-statefulset-0    Running
zookeeper1-zookeeper-statefulset-0  Running

Details of pod config1-config-statefulset-0 which is not Running:
{
  "metadata": {
    "name": "config1-config-statefulset-0",
    "generateName": "config1-config-statefulset-",
    "namespace": "contrail",
    "selfLink": "/api/v1/namespaces/contrail/pods/config1-config-statefulset-0",
    "uid": "0693393f-6624-4e31-b3ce-f69bcbbda0cf",
    "resourceVersion": "7264",
    "creationTimestamp": "2020-02-03T14:00:47Z",
    "labels": {
      "config": "config1",
      "contrail_manager": "config",
      "controller-revision-hash": "config1-config-statefulset-694cf84b59",
      "peers_ready": "true",
      "statefulset.kubernetes.io/pod-name": "config1-config-statefulset-0",
      "status": "ready",
      "version": "1"
    },
    "annotations": {
      "hostname": "config1-config-statefulset-0.config.contrail.svc.cluster.local"
    },
    "ownerReferences": [
      {
        "apiVersion": "apps/v1",
        "kind": "StatefulSet",
        "name": "config1-config-statefulset",
        "uid": "b67b1045-8199-44ac-83b0-81b5207c7769",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ]
  },
  "spec": {
    "volumes": [
      {
        "name": "tftp",
        "persistentVolumeClaim": {
          "claimName": "config1-config-tftp"
        }
      },
      {
        "name": "dnsmasq",
        "persistentVolumeClaim": {
          "claimName": "config1-config-dnsmasq"
        }
      },
      {
        "name": "config-logs",
        "hostPath": {
          "path": "/var/log/contrail/config",
          "type": ""
        }
      },
      {
        "name": "crashes",
        "hostPath": {
          "path": "/var/contrail/crashes",
          "type": ""
        }
      },
      {
        "name": "config-data",
        "hostPath": {
          "path": "/var/lib/contrail/config",
          "type": ""
        }
      },
      {
        "name": "docker-unix-socket",
        "hostPath": {
          "path": "/var/run",
          "type": ""
        }
      },
      {
        "name": "host-usr-bin",
        "hostPath": {
          "path": "/usr/bin",
          "type": ""
        }
      },
      {
        "name": "status",
        "downwardAPI": {
          "items": [
            {
              "path": "pod_labels",
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "metadata.labels"
              }
            },
            {
              "path": "peers_ready",
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "metadata.labels"
              }
            },
            {
              "path": "pod_labelsx",
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "metadata.labels"
              }
            }
          ],
          "defaultMode": 420
        }
      },
      {
        "name": "config1-config-volume",
        "configMap": {
          "name": "config1-config-configmap",
          "defaultMode": 420
        }
      },
      {
        "name": "config1-secret-certificates",
        "secret": {
          "secretName": "config1-secret-certificates",
          "defaultMode": 420
        }
      },
      {
        "name": "default-token-qgsm6",
        "secret": {
          "secretName": "default-token-qgsm6",
          "defaultMode": 420
        }
      }
    ],
    "initContainers": [
      {
        "name": "init",
        "image": "registry:5000/python:alpine",
        "command": [
          "sh",
          "-c",
          "until grep ready /tmp/podinfo/pod_labels \u003e /dev/null 2\u003e\u00261; do sleep 1; done"
        ],
        "env": [
          {
            "name": "CONTRAIL_STATUS_IMAGE",
            "value": "docker.io/michaelhenkel/contrail-status:5.2.0-dev1"
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "status",
            "mountPath": "/tmp/podinfo"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "init2",
        "image": "registry:5000/busybox",
        "command": [
          "sh",
          "-c",
          "until grep true /tmp/podinfo/peers_ready \u003e /dev/null 2\u003e\u00261; do sleep 1; done"
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "status",
            "mountPath": "/tmp/podinfo"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "nodeinit",
        "image": "registry:5000/contrail-node-init:1912-latest",
        "env": [
          {
            "name": "CONTRAIL_STATUS_IMAGE",
            "value": "docker.io/michaelhenkel/contrail-status:5.2.0-dev1"
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "host-usr-bin",
            "mountPath": "/host/usr/bin"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always",
        "securityContext": {
          "privileged": true
        }
      }
    ],
    "containers": [
      {
        "name": "api",
        "image": "registry:5000/contrail-controller-config-api:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-api --conf_file /etc/mycontrail/api.${POD_IP} --conf_file /etc/contrail/contrail-keystone-auth.conf --worker_id 0"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "readinessProbe": {
          "httpGet": {
            "path": "/",
            "port": 8082,
            "scheme": "HTTPS"
          },
          "timeoutSeconds": 1,
          "periodSeconds": 10,
          "successThreshold": 1,
          "failureThreshold": 3
        },
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "devicemanager",
        "image": "registry:5000/contrail-controller-config-devicemgr:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-device-manager --conf_file /etc/mycontrail/devicemanager.${POD_IP} --conf_file /etc/contrail/contrail-keystone-auth.conf"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "tftp",
            "mountPath": "/var/lib/tftp"
          },
          {
            "name": "dnsmasq",
            "mountPath": "/var/lib/dnsmasq"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always",
        "securityContext": {
          "capabilities": {
            "add": [
              "SYS_PTRACE"
            ]
          }
        }
      },
      {
        "name": "dnsmasq",
        "image": "registry:5000/contrail-external-dnsmasq:1910-latest",
        "command": [
          "bash",
          "-c",
          "mkdir -p /etc/tftp; dnsmasq -k -p0 --conf-file=/etc/mycontrail/dnsmasq.${POD_IP}"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "tftp",
            "mountPath": "/var/lib/tftp"
          },
          {
            "name": "dnsmasq",
            "mountPath": "/var/lib/dnsmasq"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always",
        "securityContext": {
          "capabilities": {
            "add": [
              "NET_ADMIN",
              "NET_RAW"
            ]
          }
        }
      },
      {
        "name": "schematransformer",
        "image": "registry:5000/contrail-controller-config-schema:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-schema --conf_file /etc/mycontrail/schematransformer.${POD_IP}  --conf_file /etc/contrail/contrail-keystone-auth.conf"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "servicemonitor",
        "image": "registry:5000/contrail-controller-config-svcmonitor:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-svc-monitor --conf_file /etc/mycontrail/servicemonitor.${POD_IP} --conf_file /etc/contrail/contrail-keystone-auth.conf"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "analyticsapi",
        "image": "registry:5000/contrail-analytics-api:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/python /usr/bin/contrail-analytics-api -c /etc/mycontrail/analyticsapi.${POD_IP} -c /etc/contrail/contrail-keystone-auth.conf"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          },
          {
            "name": "ANALYTICSDB_ENABLE",
            "value": "true"
          },
          {
            "name": "ANALYTICS_ALARM_ENABLE",
            "value": "true"
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "queryengine",
        "image": "registry:5000/contrail-analytics-query-engine:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/contrail-query-engine --conf_file /etc/mycontrail/queryengine.${POD_IP}"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "collector",
        "image": "registry:5000/contrail-analytics-collector:1912-latest",
        "command": [
          "bash",
          "-c",
          "/usr/bin/contrail-collector --conf_file /etc/mycontrail/collector.${POD_IP}"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "config1-secret-certificates",
            "mountPath": "/etc/certificates"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      },
      {
        "name": "redis",
        "image": "registry:5000/redis:4.0.2",
        "command": [
          "bash",
          "-c",
          "redis-server --lua-time-limit 15000 --dbfilename '' --bind 127.0.0.1 ${POD_IP} --port 6379"
        ],
        "env": [
          {
            "name": "POD_IP",
            "valueFrom": {
              "fieldRef": {
                "apiVersion": "v1",
                "fieldPath": "status.podIP"
              }
            }
          }
        ],
        "resources": {},
        "volumeMounts": [
          {
            "name": "config-logs",
            "mountPath": "/var/log/contrail"
          },
          {
            "name": "config-data",
            "mountPath": "/var/lib/redis"
          },
          {
            "name": "config1-config-volume",
            "mountPath": "/etc/mycontrail"
          },
          {
            "name": "default-token-qgsm6",
            "readOnly": true,
            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
          }
        ],
        "terminationMessagePath": "/dev/termination-log",
        "terminationMessagePolicy": "File",
        "imagePullPolicy": "Always"
      }
    ],
    "restartPolicy": "Always",
    "terminationGracePeriodSeconds": 30,
    "dnsPolicy": "ClusterFirst",
    "nodeSelector": {
      "node-role.kubernetes.io/master": ""
    },
    "serviceAccountName": "default",
    "serviceAccount": "default",
    "nodeName": "kind-control-plane",
    "shareProcessNamespace": true,
    "securityContext": {},
    "imagePullSecrets": [
      {
        "name": "contrail-nightly"
      }
    ],
    "hostname": "config1-config-statefulset-0",
    "subdomain": "config",
    "schedulerName": "default-scheduler",
    "tolerations": [
      {
        "operator": "Exists",
        "effect": "NoSchedule"
      },
      {
        "operator": "Exists",
        "effect": "NoExecute"
      }
    ],
    "priority": 0,
    "enableServiceLinks": true
  },
  "status": {
    "phase": "Pending",
    "conditions": [
      {
        "type": "Initialized",
        "status": "False",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-02-03T14:00:48Z",
        "reason": "ContainersNotInitialized",
        "message": "containers with incomplete status: [init2 nodeinit]"
      },
      {
        "type": "Ready",
        "status": "False",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-02-03T14:00:48Z",
        "reason": "ContainersNotReady",
        "message": "containers with unready status: [api devicemanager dnsmasq schematransformer servicemonitor analyticsapi queryengine collector redis]"
      },
      {
        "type": "ContainersReady",
        "status": "False",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-02-03T14:00:48Z",
        "reason": "ContainersNotReady",
        "message": "containers with unready status: [api devicemanager dnsmasq schematransformer servicemonitor analyticsapi queryengine collector redis]"
      },
      {
        "type": "PodScheduled",
        "status": "True",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-02-03T14:00:48Z"
      }
    ],
    "hostIP": "10.255.0.3",
    "podIP": "10.244.0.24",
    "startTime": "2020-02-03T14:00:48Z",
    "initContainerStatuses": [
      {
        "name": "init",
        "state": {
          "terminated": {
            "exitCode": 0,
            "reason": "Completed",
            "startedAt": "2020-02-03T14:00:48Z",
            "finishedAt": "2020-02-03T14:00:52Z",
            "containerID": "containerd://d246777d492e004a091f44d6df4309f4ec00255fa334066c658131753669c3e0"
          }
        },
        "lastState": {},
        "ready": true,
        "restartCount": 0,
        "image": "registry:5000/python:alpine",
        "imageID": "registry:5000/python@sha256:cbfcea228e685aa3684f7a4e19be4805e3bf766f2158a4e3a54443cb608c1760",
        "containerID": "containerd://d246777d492e004a091f44d6df4309f4ec00255fa334066c658131753669c3e0"
      },
      {
        "name": "init2",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/busybox",
        "imageID": ""
      },
      {
        "name": "nodeinit",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-node-init:1912-latest",
        "imageID": ""
      }
    ],
    "containerStatuses": [
      {
        "name": "analyticsapi",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-analytics-api:1912-latest",
        "imageID": ""
      },
      {
        "name": "api",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-controller-config-api:1912-latest",
        "imageID": ""
      },
      {
        "name": "collector",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-analytics-collector:1912-latest",
        "imageID": ""
      },
      {
        "name": "devicemanager",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-controller-config-devicemgr:1912-latest",
        "imageID": ""
      },
      {
        "name": "dnsmasq",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-external-dnsmasq:1910-latest",
        "imageID": ""
      },
      {
        "name": "queryengine",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-analytics-query-engine:1912-latest",
        "imageID": ""
      },
      {
        "name": "redis",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/redis:4.0.2",
        "imageID": ""
      },
      {
        "name": "schematransformer",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-controller-config-schema:1912-latest",
        "imageID": ""
      },
      {
        "name": "servicemonitor",
        "state": {
          "waiting": {
            "reason": "PodInitializing"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "registry:5000/contrail-controller-config-svcmonitor:1912-latest",
        "imageID": ""
      }
    ],
    "qosClass": "BestEffort"
  }
}
```