### PR TITLE
Add subpath to the postgres volume mount

### DIFF
--- a/pkg/controller/postgres/postgres_controller.go
+++ b/pkg/controller/postgres/postgres_controller.go
@@ -195,6 +195,7 @@ func newPodForCR(cr *contrail.Postgres, claimName string) *core.Pod {
 					VolumeMounts: []core.VolumeMount{{
 						Name:      cr.Name + "-volume",
 						MountPath: "/var/lib/postgresql/data",
+						SubPath: "postgres",
 					}},
 					Env: []core.EnvVar{
 						{Name: "POSTGRES_USER", Value: "root"},


### PR DESCRIPTION
When using AWS EBS volumes, the root (`/`) directory is not empty, it contains a directory called `lost+found`. Because of this, the postgres container fails with an error:

`initdb: directory "/var/lib/postgresql/data" exists but is not empty It contains a lost+found directory, perhaps due to it being a mount point. Using a mount point directly as the data directory is not recommended. Create a subdirectory under the mount point.`

This can be fixed by adding a subPath (with a value of, for example, `postgres`) to the volume mount. Then, the volume is mounted under an empty `/postgres` dir and postgres initializes succesfully.

Ref:  https://stackoverflow.com/questions/51168558/how-to-mount-a-postgresql-volume-using-aws-ebs-in-kubernete
