### PR TITLE
Remove hardcoded cassandra imagePullSecrets

### DIFF
--- a/pkg/controller/cassandra/sts.go
+++ b/pkg/controller/cassandra/sts.go
@@ -64,8 +64,6 @@ spec:
         #  name: cassandra-data
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      imagePullSecrets:
-      - name: contrail
       initContainers:
       - command:
         - sh


### PR DESCRIPTION
In Openshift, imagePullSecrets that give access to the cluster's internal container registry are automatically assigned to pods. Hardcoded imagePullSecrets under the Cassandra Statefulset spec disabled it (no default cluster secret was assigned to the Pod, only the hardcoded one), so Pod creation failed with the 'ImagePullBackOff' error.