### PR TITLE
Idempotent init2 cassandra

### DIFF
--- a/pkg/controller/cassandra/cassandra_controller.go
+++ b/pkg/controller/cassandra/cassandra_controller.go
@@ -354,7 +354,7 @@ func (r *ReconcileCassandra) Reconcile(request reconcile.Request) (reconcile.Res
 		}
 		if container.Name == "init2" {
 			command := []string{"bash", "-c",
-				"keytool -keystore /etc/keystore/server-truststore.jks -keypass " + cassandraKeystorePassword + " -storepass " + cassandraTruststorePassword + " -list -alias CARoot -noprompt;" + 
+				"keytool -keystore /etc/keystore/server-truststore.jks -keypass " + cassandraKeystorePassword + " -storepass " + cassandraTruststorePassword + " -list -alias CARoot -noprompt;" +
 				"if [ $? -ne 0 ]; then keytool -keystore /etc/keystore/server-truststore.jks -keypass " + cassandraKeystorePassword + " -storepass " + cassandraTruststorePassword + " -noprompt -alias CARoot -import -file /run/secrets/kubernetes.io/serviceaccount/ca.crt; fi && " +
 				"openssl pkcs12 -export -in /etc/certificates/server-${POD_IP}.crt -inkey /etc/certificates/server-key-${POD_IP}.pem -chain -CAfile /run/secrets/kubernetes.io/serviceaccount/ca.crt -password pass:" + cassandraTruststorePassword + " -name $(hostname -f) -out TmpFile && " +
 				"keytool -importkeystore -deststorepass " + cassandraKeystorePassword + " -destkeypass " + cassandraKeystorePassword + " -destkeystore /etc/keystore/server-keystore.jks -deststoretype pkcs12 -srcstorepass " + cassandraTruststorePassword + " -srckeystore TmpFile -srcstoretype PKCS12 -alias $(hostname -f) -noprompt;"}


### PR DESCRIPTION
Modify command of the init2 cassandra container to check whether there are any certs under the specified alias. Only if there are none, new certificate will be imported.

Before, in case of an error/restart, the `keytool -import` would fail with an error:
`keytool error: java.lang.Exception: Certificate not imported, alias <CAroot> already exists`
