### PR TITLE
Refactor YAMLs of kubemanager and vrouter

### DIFF
--- a/pkg/controller/kubemanager/sts.go
+++ b/pkg/controller/kubemanager/sts.go
@@ -29,7 +29,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       initContainers:
-        - name: init-wait-pod-ready
+        - name: init
           image: busybox
           command:
             - sh
@@ -42,7 +42,7 @@ spec:
             - name: CONTRAIL_STATUS_IMAGE
               value: docker.io/michaelhenkel/contrail-status:5.2.0-dev1
           imagePullPolicy: Always
-        - name: contrail-node-init
+        - name: nodeinit
           image: docker.io/michaelhenkel/contrail-node-init:5.2.0-dev1
           env:
             - name: CONTRAIL_STATUS_IMAGE

--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -29,7 +29,7 @@ spec:
         - operator: Exists
           effect: NoExecute
       initContainers:
-        - name: init-wait-pod-ready
+        - name: init
           image: busybox
           command:
             - sh


### PR DESCRIPTION
I refactored YAMLs of kubemanager and vrouter.

I've added indentations and some order of entries to make it readable for humans. :)

