### PR TITLE
Format cluster_info.go files

### DIFF
--- a/pkg/k8s/cluster_info.go
+++ b/pkg/k8s/cluster_info.go
@@ -113,8 +113,8 @@ func (c ClusterConfig) ServiceSubnets() (string, error) {
 }
 
 type configMap struct {
-	ControlPlaneEndpoint string           `yaml:"controlPlaneEndpoint"`
-	ClusterName          string           `yaml:"clusterName"`
+	ControlPlaneEndpoint string     `yaml:"controlPlaneEndpoint"`
+	ClusterName          string     `yaml:"clusterName"`
 	Networking           networking `yaml:"networking"`
 }
 

--- a/pkg/openshift/cluster_info.go
+++ b/pkg/openshift/cluster_info.go
@@ -140,7 +140,7 @@ type metadata struct {
 
 type networking struct {
 	ClusterNetwork []clusterNetwork `yaml:"clusterNetwork"`
-	ServiceNetwork []string               `yaml:"serviceNetwork"`
+	ServiceNetwork []string         `yaml:"serviceNetwork"`
 }
 
 type clusterNetwork struct {


### PR DESCRIPTION
Apparently, I missed something in my PR #70 and cluster_info.go files for both k8s and openshift has small format mistakes.

I've run go fmt on them to fix that.
Sorry :)