### PR TITLE
Fix statusmonitor compilation and change image to kaweue/contrail-sta…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,5 @@ statusmonitor:
 
 provisioner:
 	cd $(ROOT_DIR)/contrail-provisioner && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o contrail-provisioner && docker build . -t contrail-provisioner:master.1115
+
+.PHONY: statusmonitor provisioner generate

--- a/deploy/2-start-operator-1node.yaml
+++ b/deploy/2-start-operator-1node.yaml
@@ -91,7 +91,7 @@ spec:
             nodeinit:
               image: opencontrailnightly/contrail-node-init:1910-latest
             statusmonitor:
-              image: michaelhenkel/contrail-statusmonitor:debug
+              image: kaweue/contrail-statusmonitor:debug
           zookeeperInstance: zookeeper1
     kubemanagers:
     - metadata:

--- a/deploy/2-start-operator-3node.yaml
+++ b/deploy/2-start-operator-3node.yaml
@@ -91,7 +91,7 @@ spec:
             nodeinit:
               image: opencontrailnightly/contrail-node-init:1910-latest
             statusmonitor:
-              image: michaelhenkel/contrail-statusmonitor:debug
+              image: kaweue/contrail-statusmonitor:debug
           zookeeperInstance: zookeeper1
     kubemanagers:
     - metadata:

--- a/deploy/crds/contrail_v1alpha1_manager_cr.yaml
+++ b/deploy/crds/contrail_v1alpha1_manager_cr.yaml
@@ -91,7 +91,7 @@ spec:
             nodeinit:
               image: opencontrailnightly/contrail-node-init:1910-latest
             statusmonitor:
-              image: michaelhenkel/contrail-statusmonitor:debug
+              image: kaweue/contrail-statusmonitor:debug
           zookeeperInstance: zookeeper1
     kubemanagers:
     - metadata:

--- a/pkg/controller/control/sts.go
+++ b/pkg/controller/control/sts.go
@@ -70,7 +70,7 @@ spec:
             - mountPath: /var/log/contrail
               name: control-logs
         - name: statusmonitor
-          image: docker.io/michaelhenkel/contrail-statusmonitor:debug
+          image: docker.io/kaweue/contrail-statusmonitor:debug
           env:
             - name: POD_IP
               valueFrom:

--- a/statusmonitor/main.go
+++ b/statusmonitor/main.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -209,7 +209,8 @@ func getPods(config Config, clientSet *kubernetes.Clientset) ([]string, error) {
 }
 
 func kubeClient(config Config) (*kubernetes.Clientset, *rest.RESTClient, error) {
-	
+
+	var err error
 	clientset := &kubernetes.Clientset{}
 	restClient := &rest.RESTClient{}
 	kubeConfig := &rest.Config{}

--- a/test/env/update_local_registry.sh
+++ b/test/env/update_local_registry.sh
@@ -68,14 +68,9 @@ EOF
 pull_image tmaier postgresql-client
 
 while read line; do
-	pull_image michaelhenkel "${line}"
-done <<EOF
-contrail-statusmonitor:debug
-EOF
-
-while read line; do
 	pull_image kaweue "${line}"
 done <<EOF
+contrail-statusmonitor:debug
 contrail-controller-config-dnsmasq:dev
 contrail-provisioner:master.1115
 EOF


### PR DESCRIPTION
Deployment used in `test/env/deploy/cluster.yaml` was broken by updated statusmonitor docker image. In order to fix that I build this container and push into shared docker.io image registry `kaweue`. 

Also `Makefile` needed alignment to properly build  statusmonitor and I fix `statusmonitor/main.go` compilation error. 