### PR TITLE
Make memcached available only on localhost

### DIFF
--- a/pkg/controller/memcached/memcached_config_maps.go
+++ b/pkg/controller/memcached/memcached_config_maps.go
@@ -50,7 +50,8 @@ func (c *memcachedConfig) String() string {
 	return buffer.String()
 }
 
+// -l 127.0.0.1 makes memcached available only on localhost
 const memcachedConfigTemplate = `{
-	"command": "/usr/bin/memcached -v -l 0.0.0.0 -p {{ .ListenPort }} -c {{ .ConnectionLimit }} -U 0 -m {{ .MaxMemory }}",
+	"command": "/usr/bin/memcached -vv -l 127.0.0.1 -p {{ .ListenPort }} -c {{ .ConnectionLimit }} -U 0 -m {{ .MaxMemory }}",
 	"config_files": []
 }`

--- a/pkg/controller/memcached/memcached_controller.go
+++ b/pkg/controller/memcached/memcached_controller.go
@@ -134,7 +134,7 @@ func (r *ReconcileMemcached) updateStatus(memcachedCR *contrail.Memcached, deplo
 		if len(pods.Items) != 1 {
 			return fmt.Errorf("ReconcileMemchached.updateStatus: expected 1 pod with labels %v, got %d", labels, len(pods.Items))
 		}
-		ip := pods.Items[0].Status.PodIP
+		ip := "127.0.0.1" // memcached is available only on localhost for security reasons, after configuring SSL this should be changed to pods.Items[0].Status.PodIP
 		port := memcachedCR.Spec.ServiceConfiguration.GetListenPort()
 		memcachedCR.Status.Node = fmt.Sprintf("%s:%d", ip, port)
 		memcachedCR.Status.Active = true

--- a/pkg/controller/memcached/memcached_controller_test.go
+++ b/pkg/controller/memcached/memcached_controller_test.go
@@ -266,7 +266,7 @@ func newExpectedDeployment() *apps.Deployment {
 func newExpectedMemcachedConfigMap() *core.ConfigMap {
 	trueVal := true
 	expectedConfig := `{
-	"command": "/usr/bin/memcached -v -l 0.0.0.0 -p 11211 -c 5000 -U 0 -m 256",
+	"command": "/usr/bin/memcached -vv -l 127.0.0.1 -p 11211 -c 5000 -U 0 -m 256",
 	"config_files": []
 }`
 	return &core.ConfigMap{


### PR DESCRIPTION
Tests that I performed manually:
1. Using python memcached client, perform some simple requests in 2 variants:
- `kubectl port-forward...`, make request to localhost
- find memcached pod IP with `kubectl describe`, make request to pod IP
Without changes in this pull request, both version worked. After these changes only the first version (port forwarding + request to localhost) is accepted.
2. Check in memcached logs if any data is being stored by keystone/swift. It works both with changes in this PR (i.e. with 127.0.0.1:PORT in `memcachedCR.Status.Node`) and without them (i.e. with POD_IP:PORT in `memcachedCR.Status.Node`) - so this PR does not break integration between memcached and other services, as long as there is only one k8s node.