### PR TITLE
Adding  utils_test.go BUILD.bazel for review, added new testcases for…

### DIFF
--- a/pkg/controller/utils/BUILD.bazel
+++ b/pkg/controller/utils/BUILD.bazel
@@ -26,5 +26,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/contrail/v1alpha1:go_default_library",
+        "@io_k8s_api//apps/v1:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/event:go_default_library",
     ],
 )

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -82,6 +82,261 @@ func TestUtils(t *testing.T) {
 	})
 }
 
+func TestUtilsSecond(t *testing.T) {
+	falseVal := false
+	metaobj := meta.ObjectMeta{}
+	or := meta.OwnerReference{
+		APIVersion:         "v1",
+		Kind:               "owner-kind",
+		Name:               "owner-name",
+		UID:                "owner-uid",
+		Controller:         &falseVal,
+		BlockOwnerDeletion: &falseVal,
+	}
+	ors := []meta.OwnerReference{or}
+	metaobj.SetOwnerReferences(ors)
+	pod := &core.Pod{
+		ObjectMeta: metaobj,
+	}
+	scheme, err := contrail.SchemeBuilder.Build()
+	require.NoError(t, err, "Failed to build scheme")
+	require.NoError(t, core.SchemeBuilder.AddToScheme(scheme), "Failed core.SchemeBuilder.AddToScheme()")
+	require.NoError(t, apps.SchemeBuilder.AddToScheme(scheme), "Failed apps.SchemeBuilder.AddToScheme()")
+
+	t.Run("Update Event in ZookeeperActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newZookeeper(),
+			MetaNew:   pod,
+			ObjectNew: newZookeeper(),
+		}
+		hf := tm.ZookeeperActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in RabbitmqActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newRabbitmq(),
+			MetaNew:   pod,
+			ObjectNew: newRabbitmq(),
+		}
+		hf := tm.RabbitmqActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in ControlActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: control,
+			MetaNew:   pod,
+			ObjectNew: control,
+		}
+		hf := tm.ControlActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in VrouterActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: vrouter,
+			MetaNew:   pod,
+			ObjectNew: vrouter,
+		}
+		hf := tm.VrouterActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in ConfigActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: config,
+			MetaNew:   pod,
+			ObjectNew: config,
+		}
+		hf := tm.ConfigActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in CassandraActiveChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: cassandra,
+			MetaNew:   pod,
+			ObjectNew: cassandra,
+		}
+		hf := tm.CassandraActiveChange()
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in ManagerSizeChange/CassandraGroupKind verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newManager(),
+			MetaNew:   pod,
+			ObjectNew: newManager(),
+		}
+		hf := tm.ManagerSizeChange(tm.CassandraGroupKind())
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in ManagerSizeChange/ZookeeperGroupKind verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newManager(),
+			MetaNew:   pod,
+			ObjectNew: newManager(),
+		}
+		hf := tm.ManagerSizeChange(tm.ZookeeperGroupKind())
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in ManagerSizeChange/RabbitmqGroupKind verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newManager(),
+			MetaNew:   pod,
+			ObjectNew: newManager(),
+		}
+		hf := tm.ManagerSizeChange(tm.RabbitmqGroupKind())
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in DSStatusChange/VrouterGroupKind verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: DaemonSet,
+			MetaNew:   pod,
+			ObjectNew: DaemonSet,
+		}
+		hf := tm.DSStatusChange(tm.VrouterGroupKind())
+		status = hf.UpdateFunc(evu)
+		hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in DeploymentStatusChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newDeployment(),
+			MetaNew:   pod,
+			ObjectNew: newDeployment(),
+		}
+		hf := tm.DeploymentStatusChange(tm.VrouterGroupKind())
+		status = hf.UpdateFunc(evu)
+		hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+	t.Run("Update Event in STSStatusChange verification", func(t *testing.T) {
+		expectedStatus := false
+		status := true
+		evu := event.UpdateEvent{
+			MetaOld:   pod,
+			ObjectOld: newStatefulSet(),
+			MetaNew:   pod,
+			ObjectNew: newStatefulSet(),
+		}
+		hf := tm.STSStatusChange(tm.CassandraGroupKind())
+		status = hf.UpdateFunc(evu)
+		assert.Equal(t, status, expectedStatus)
+	})
+
+}
+
+var (
+	replicas int32 = 3
+	create         = true
+)
+
+var cassandra = &contrail.Cassandra{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "cassandra1",
+		Namespace: "default",
+		Labels:    map[string]string{"contrail_cluster": "cluster1"},
+	},
+	Spec: contrail.CassandraSpec{
+		CommonConfiguration: contrail.CommonConfiguration{
+			Create:   &create,
+			Replicas: &replicas,
+		},
+		ServiceConfiguration: contrail.CassandraConfiguration{
+			Containers: map[string]*contrail.Container{
+				"cassandra": &contrail.Container{Image: "cassandra:3.5"},
+				"init":      &contrail.Container{Image: "busybox"},
+				"init2":     &contrail.Container{Image: "cassandra:3.5"},
+			},
+		},
+	},
+}
+
+func newRabbitmq() *contrail.Rabbitmq {
+	trueVal := true
+	falseVal := false
+	replica := int32(1)
+	return &contrail.Rabbitmq{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "rabbitmq-instance",
+			Namespace: "default",
+			Labels:    map[string]string{"contrail_cluster": "config1"},
+			OwnerReferences: []meta.OwnerReference{
+				{
+					Name:       "config1",
+					Kind:       "Manager",
+					Controller: &trueVal,
+				},
+			},
+		},
+		Spec: contrail.RabbitmqSpec{
+			CommonConfiguration: contrail.CommonConfiguration{
+				Activate:     &trueVal,
+				Create:       &trueVal,
+				HostNetwork:  &trueVal,
+				Replicas:     &replica,
+				NodeSelector: map[string]string{"node-role.kubernetes.io/master": ""},
+			},
+			ServiceConfiguration: contrail.RabbitmqConfiguration{
+				Containers: map[string]*contrail.Container{
+					"init":     &contrail.Container{Image: "python:alpine"},
+					"rabbitmq": &contrail.Container{Image: "contrail-controller-rabbitmq"},
+				},
+			},
+		},
+		Status: contrail.RabbitmqStatus{Active: &falseVal},
+	}
+}
+
 func newZookeeper() *contrail.Zookeeper {
 	trueVal := true
 	falseVal := false
@@ -118,38 +373,140 @@ func newZookeeper() *contrail.Zookeeper {
 	}
 }
 
-func TestUtilsSecond(t *testing.T) {
-	falseVal := false
-	metaobj := meta.ObjectMeta{}
-	or := meta.OwnerReference{
-		APIVersion:         "v1",
-		Kind:               "owner-kind",
-		Name:               "owner-name",
-		UID:                "owner-uid",
-		Controller:         &falseVal,
-		BlockOwnerDeletion: &falseVal,
-	}
-	ors := []meta.OwnerReference{or}
-	metaobj.SetOwnerReferences(ors)
-	pod := &core.Pod{
-		ObjectMeta: metaobj,
-	}
-	scheme, err := contrail.SchemeBuilder.Build()
-	require.NoError(t, err, "Failed to build scheme")
-	require.NoError(t, core.SchemeBuilder.AddToScheme(scheme), "Failed core.SchemeBuilder.AddToScheme()")
-	require.NoError(t, apps.SchemeBuilder.AddToScheme(scheme), "Failed apps.SchemeBuilder.AddToScheme()")
+var rbt = newRabbitmq()
+var zoo = newZookeeper()
 
-	t.Run("Update Event in ZookeeperActiveChange verification", func(t *testing.T) {
-		expectedStatus := false
-		status := true
-		evu := event.UpdateEvent{
-			MetaOld:   pod,
-			ObjectOld: newZookeeper(),
-			MetaNew:   pod,
-			ObjectNew: newZookeeper(),
-		}
-		hf := tm.ZookeeperActiveChange()
-		status = hf.UpdateFunc(evu)
-		assert.Equal(t, status, expectedStatus)
-	})
+func newManager() *contrail.Manager {
+	return &contrail.Manager{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "config1",
+			Namespace: "default",
+			Labels:    map[string]string{"contrail_cluster": "config1"},
+		},
+		Spec: contrail.ManagerSpec{
+			Services: contrail.Services{
+				Zookeepers: []*contrail.Zookeeper{zoo},
+				Cassandras: []*contrail.Cassandra{cassandra},
+				Rabbitmq:   rbt,
+			},
+		},
+		Status: contrail.ManagerStatus{},
+	}
+}
+
+var control = &contrail.Control{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "control1",
+		Namespace: "default",
+		Labels: map[string]string{
+			"contrail_cluster": "cluster1",
+			"control_role":     "master",
+		},
+	},
+}
+
+var kubemanager = &contrail.Kubemanager{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "kubemanager1",
+		Namespace: "default",
+		Labels: map[string]string{
+			"contrail_cluster": "cluster1",
+		},
+	},
+}
+
+var vrouter = &contrail.Vrouter{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "vrouter",
+		Namespace: "default",
+		Labels: map[string]string{
+			"contrail_cluster": "cluster1",
+		},
+	},
+	Spec: contrail.VrouterSpec{
+		ServiceConfiguration: contrail.VrouterConfiguration{
+			ControlInstance: "control1",
+			Gateway:         "1.1.8.254",
+		},
+	},
+}
+
+var keystone = &contrail.Keystone{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "keystone",
+		Namespace: "default",
+		Labels: map[string]string{
+			"contrail_cluster": "cluster1",
+		},
+	},
+	Spec: contrail.KeystoneSpec{
+		ServiceConfiguration: contrail.KeystoneConfiguration{
+			ListenPort: 5555,
+		},
+	},
+	Status: contrail.KeystoneStatus{
+		IPs: []string{"10.11.12.13"},
+	},
+}
+
+var config = &contrail.Config{
+	ObjectMeta: meta.ObjectMeta{
+		Name:      "config1",
+		Namespace: "default",
+		Labels: map[string]string{
+			"contrail_cluster": "cluster1",
+		},
+	},
+	Spec: contrail.ConfigSpec{
+		ServiceConfiguration: contrail.ConfigConfiguration{
+			KeystoneSecretName: "keystone-adminpass-secret",
+			AuthMode:           contrail.AuthenticationModeKeystone,
+		},
+	},
+}
+
+var DaemonSet = GetDaemonset()
+
+func GetDaemonset() *apps.DaemonSet {
+	var daemonSet = apps.DaemonSet{
+		TypeMeta: meta.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "vrouter",
+			Namespace: "default",
+		},
+	}
+	return &daemonSet
+}
+
+func newDeployment() *apps.Deployment {
+	trueVal := true
+	return &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "test-memcached-deployment",
+			Namespace: "default",
+			OwnerReferences: []meta.OwnerReference{
+				{"contrail.juniper.net/v1alpha1", "Memcached", "test-memcached", "", &trueVal, &trueVal},
+			},
+			Labels: map[string]string{"Memcached": "test-memcached"},
+		},
+		TypeMeta: meta.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+	}
+}
+
+func newStatefulSet() *apps.StatefulSet {
+	trueVal := true
+	return &apps.StatefulSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "statefulset",
+			Namespace: "default",
+			Labels:    map[string]string{"contrail_manager": "keystone", "keystone": "keystone"},
+			OwnerReferences: []meta.OwnerReference{
+				{"contrail.juniper.net/v1alpha1", "Keystone", "keystone", "", &trueVal, &trueVal},
+			},
+		},
+		TypeMeta: meta.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},
+	}
 }


### PR DESCRIPTION
Adding  utils_test.go BUILD.bazel for review, added new test cases for verification, also updated the Bazel for Build.

vraparla-mbp:utils vraparla$ t
=== RUN   TestUtils
=== RUN   TestUtils/testing_utils_with_WebuiGroupKind
=== RUN   TestUtils/testing_utils_with_kind_Vrouter.
=== RUN   TestUtils/testing_utils_with_kind_ControlGroupKind
=== RUN   TestUtils/testing_utils_with_kind_ConfigGroupKind
=== RUN   TestUtils/testing_utils_with_kind_KubemanagerGroupKind
=== RUN   TestUtils/testing_utils_with_kind_CassandraGroupKind
=== RUN   TestUtils/testing_utils_with_kind_ZookeeperGroupKind
=== RUN   TestUtils/testing_utils_with_kind_RabbitmqGroupKind
=== RUN   TestUtils/testing_utils_with_kind_ManagerGroupKind
=== RUN   TestUtils/testing_utils_with_kind_ReplicaSetGroupKind
=== RUN   TestUtils/testing_utils_with_kind_DeploymentGroupKind
--- PASS: TestUtils (0.00s)
    --- PASS: TestUtils/testing_utils_with_WebuiGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_Vrouter. (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_ControlGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_ConfigGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_KubemanagerGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_CassandraGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_ZookeeperGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_RabbitmqGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_ManagerGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_ReplicaSetGroupKind (0.00s)
    --- PASS: TestUtils/testing_utils_with_kind_DeploymentGroupKind (0.00s)
=== RUN   TestUtilsSecond
=== RUN   TestUtilsSecond/Update_Event_in_ZookeeperActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_RabbitmqActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_ControlActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_VrouterActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_ConfigActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_CassandraActiveChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_ManagerSizeChange/CassandraGroupKind_verification
=== RUN   TestUtilsSecond/Update_Event_in_ManagerSizeChange/ZookeeperGroupKind_verification
=== RUN   TestUtilsSecond/Update_Event_in_ManagerSizeChange/RabbitmqGroupKind_verification
=== RUN   TestUtilsSecond/Update_Event_in_DSStatusChange/VrouterGroupKind_verification
=== RUN   TestUtilsSecond/Update_Event_in_DeploymentStatusChange_verification
=== RUN   TestUtilsSecond/Update_Event_in_STSStatusChange_verification
--- PASS: TestUtilsSecond (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ZookeeperActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_RabbitmqActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ControlActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_VrouterActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ConfigActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_CassandraActiveChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ManagerSizeChange/CassandraGroupKind_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ManagerSizeChange/ZookeeperGroupKind_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_ManagerSizeChange/RabbitmqGroupKind_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_DSStatusChange/VrouterGroupKind_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_DeploymentStatusChange_verification (0.00s)
    --- PASS: TestUtilsSecond/Update_Event_in_STSStatusChange_verification (0.00s)
PASS
ok      github.com/Juniper/contrail-operator/pkg/controller/utils       0.259s
PASS

Request to check it.