### PR TITLE
Gather Endpoint Address and Port from operator config instead of configMap

### DIFF
--- a/pkg/k8s/cluster_info.go
+++ b/pkg/k8s/cluster_info.go
@@ -1,9 +1,6 @@
 package k8s
 
 import (
-	"net"
-	"strconv"
-
 	yaml "gopkg.in/yaml.v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,52 +10,6 @@ import (
 // ClusterConfig is a struct that incorporates v1alpha1.KubemanagerClusterInfo interface
 type ClusterConfig struct {
 	Client typedCorev1.CoreV1Interface
-}
-
-// KubernetesAPISSLPort gathers SSL Port from Kubernetes Cluster via kubeadm-config ConfigMap
-func (c ClusterConfig) KubernetesAPISSLPort() (int, error) {
-	kubeadmConfigMapClient := c.Client.ConfigMaps("kube-system")
-	kcm, err := kubeadmConfigMapClient.Get("kubeadm-config", metav1.GetOptions{})
-	if err != nil {
-		return 0, err
-	}
-	clusterConfig := kcm.Data["ClusterConfiguration"]
-	clusterConfigByte := []byte(clusterConfig)
-	clusterConfigMap := configMap{}
-	if err := yaml.Unmarshal(clusterConfigByte, &clusterConfigMap); err != nil {
-		return 0, err
-	}
-	controlPlaneEndpoint := clusterConfigMap.ControlPlaneEndpoint
-	_, kubernetesAPISSLPort, err := net.SplitHostPort(controlPlaneEndpoint)
-	if err != nil {
-		return 0, err
-	}
-	kubernetesAPISSLPortInt, err := strconv.Atoi(kubernetesAPISSLPort)
-	if err != nil {
-		return 0, err
-	}
-	return kubernetesAPISSLPortInt, nil
-}
-
-// KubernetesAPIServer gathers API Server from Kubernetes Cluster via kubeadm-config ConfigMap
-func (c ClusterConfig) KubernetesAPIServer() (string, error) {
-	kubeadmConfigMapClient := c.Client.ConfigMaps("kube-system")
-	kcm, err := kubeadmConfigMapClient.Get("kubeadm-config", metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	clusterConfig := kcm.Data["ClusterConfiguration"]
-	clusterConfigByte := []byte(clusterConfig)
-	clusterConfigMap := configMap{}
-	if err := yaml.Unmarshal(clusterConfigByte, &clusterConfigMap); err != nil {
-		return "", err
-	}
-	controlPlaneEndpoint := clusterConfigMap.ControlPlaneEndpoint
-	kubernetesAPIServer, _, err := net.SplitHostPort(controlPlaneEndpoint)
-	if err != nil {
-		return "", err
-	}
-	return kubernetesAPIServer, nil
 }
 
 // KubernetesClusterName gathers cluster name from Kubernetes Cluster via kubeadm-config ConfigMap
@@ -123,9 +74,8 @@ func (c ClusterConfig) CNIConfigFilesDirectory() string {
 }
 
 type configMap struct {
-	ControlPlaneEndpoint string     `yaml:"controlPlaneEndpoint"`
-	ClusterName          string     `yaml:"clusterName"`
-	Networking           networking `yaml:"networking"`
+	ClusterName string     `yaml:"clusterName"`
+	Networking  networking `yaml:"networking"`
 }
 
 type networking struct {

--- a/pkg/k8s/cluster_info_test.go
+++ b/pkg/k8s/cluster_info_test.go
@@ -57,18 +57,6 @@ func (suite *ClusterInfoSuite) SetupTest() {
 
 }
 
-func (suite *ClusterInfoSuite) TestKubernetesAPISSLPort() {
-	APISSLPort, err := suite.ClusterInfo.KubernetesAPISSLPort()
-	suite.Assert().NoError(err)
-	suite.Assert().Equal(APISSLPort, 6443, "API SSL port should be 6443")
-}
-
-func (suite *ClusterInfoSuite) TestKubernetesAPIServer() {
-	APIServer, err := suite.ClusterInfo.KubernetesAPIServer()
-	suite.Assert().NoError(err)
-	suite.Assert().Equal(APIServer, "10.255.254.3", "API Server should be 10.255.254.3")
-}
-
 func (suite *ClusterInfoSuite) TestKubernetesClusterName() {
 	clusterName, err := suite.ClusterInfo.KubernetesClusterName()
 	suite.Assert().NoError(err)
@@ -95,21 +83,6 @@ func (suite *ClusterInfoSuite) TestCNIConfigFilesDirectory() {
 	suite.Assert().Equal(suite.CNIDirs.CNIConfigFilesDirectory(), "/etc/cni", "Path should be /etc/cni")
 }
 
-func (suite *ClusterInfoSuite) TestMissingEndpointPort() {
-	var wrongKubeadmConfig = `---
-    controlPlaneEndpoint: 10.0.0.1
-    clusterName: test
-    networking:
-      podSubnet: 192.168.0.1
-      serviceSubnet: 10.0.0.0`
-	var ci v1alpha1.KubemanagerClusterInfo
-	ci = k8s.ClusterConfig{Client: getClientWithConfigMap(wrongKubeadmConfig)}
-	_, err := ci.KubernetesAPISSLPort()
-	suite.Assert().Error(err)
-	_, err = ci.KubernetesAPIServer()
-	suite.Assert().Error(err)
-}
-
 func (suite *ClusterInfoSuite) TestUnmarshableKubeadmConfig() {
 	var wrongKubeadmConfig = `---
     - controlPlaneEndpoint: 10.0.0.1:6443
@@ -121,11 +94,7 @@ func (suite *ClusterInfoSuite) TestUnmarshableKubeadmConfig() {
         - 10.0.0.0`
 	var ci v1alpha1.KubemanagerClusterInfo
 	ci = k8s.ClusterConfig{Client: getClientWithConfigMap(wrongKubeadmConfig)}
-	_, err := ci.KubernetesAPISSLPort()
-	suite.Assert().Error(err)
-	_, err = ci.KubernetesAPIServer()
-	suite.Assert().Error(err)
-	_, err = ci.KubernetesClusterName()
+	_, err := ci.KubernetesClusterName()
 	suite.Assert().Error(err)
 	_, err = ci.PodSubnets()
 	suite.Assert().Error(err)
@@ -137,11 +106,7 @@ func (suite *ClusterInfoSuite) TestMissingConfigMap() {
 	fakeClientset := fake.NewSimpleClientset()
 	var ci v1alpha1.KubemanagerClusterInfo
 	ci = k8s.ClusterConfig{Client: fakeClientset.CoreV1()}
-	_, err := ci.KubernetesAPISSLPort()
-	suite.Assert().Error(err)
-	_, err = ci.KubernetesAPIServer()
-	suite.Assert().Error(err)
-	_, err = ci.KubernetesClusterName()
+	_, err := ci.KubernetesClusterName()
 	suite.Assert().Error(err)
 	_, err = ci.PodSubnets()
 	suite.Assert().Error(err)

--- a/pkg/openshift/cluster_info.go
+++ b/pkg/openshift/cluster_info.go
@@ -1,10 +1,6 @@
 package openshift
 
 import (
-	"net"
-	"net/url"
-	"strconv"
-
 	yaml "gopkg.in/yaml.v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,36 +13,6 @@ var log = logf.Log.WithName("openshift_cluster_info")
 // ClusterConfig is a struct that incorporates v1alpha1.KubemanagerClusterInfo interface
 type ClusterConfig struct {
 	Client typedCorev1.CoreV1Interface
-}
-
-// KubernetesAPISSLPort gathers SSL Port from Openshift Cluster via console-config ConfigMap
-func (c ClusterConfig) KubernetesAPISSLPort() (int, error) {
-	masterPublicURL, err := getMasterPublicURL(c.Client)
-	if err != nil {
-		return 0, err
-	}
-	_, kubernetesAPISSLPort, err := net.SplitHostPort(masterPublicURL.Host)
-	if err != nil {
-		return 0, err
-	}
-	kubernetesAPISSLPortInt, err := strconv.Atoi(kubernetesAPISSLPort)
-	if err != nil {
-		return 0, err
-	}
-	return kubernetesAPISSLPortInt, nil
-}
-
-// KubernetesAPIServer gathers API Server name from Openshift Cluster via console-config ConfigMap
-func (c ClusterConfig) KubernetesAPIServer() (string, error) {
-	masterPublicURL, err := getMasterPublicURL(c.Client)
-	if err != nil {
-		return "", err
-	}
-	kubernetesAPIServer, _, err := net.SplitHostPort(masterPublicURL.Host)
-	if err != nil {
-		return "", err
-	}
-	return kubernetesAPIServer, nil
 }
 
 // KubernetesClusterName gathers cluster name from Openshift Cluster via cluster-config-v1 ConfigMap
@@ -97,26 +63,6 @@ func (c ClusterConfig) CNIBinariesDirectory() string {
 // CNIConfigFilesDirectory returns directory containing CNI config files specific for k8s cluster
 func (c ClusterConfig) CNIConfigFilesDirectory() string {
 	return "/etc/kubernetes/cni"
-}
-
-func getMasterPublicURL(client typedCorev1.CoreV1Interface) (*url.URL, error) {
-	openshiftConsoleMapClient := client.ConfigMaps("openshift-console")
-	consoleCM, err := openshiftConsoleMapClient.Get("console-config", metav1.GetOptions{})
-	if err != nil {
-		return &url.URL{}, err
-	}
-	consoleConfigSection := consoleCM.Data["console-config.yaml"]
-	consoleConfigByte := []byte(consoleConfigSection)
-	consoleConfigMap := consoleConfig{}
-	if err := yaml.Unmarshal(consoleConfigByte, &consoleConfigMap); err != nil {
-		return &url.URL{}, err
-	}
-	masterPublicURL := consoleConfigMap.ClusterInfo.MasterPublicURL
-	parsedMasterPublicURL, err := url.Parse(masterPublicURL)
-	if err != nil {
-		return &url.URL{}, err
-	}
-	return parsedMasterPublicURL, nil
 }
 
 func getInstallConfig(client typedCorev1.CoreV1Interface) (installConfig, error) {


### PR DESCRIPTION
In this review I moved logic of gathering Endpoint SSL Server Address and Port to native operator config that's provided with every reconcile instead of configMap.

Usage of configMap was problematic for Openshift, because running contrail on Openshift install caused errors due to missing config map with Endpoint URL (installer has already deleted standard kubernetes configMap from kube-system, but has not created configMap for console which was used).

This solution is more native for operator and does not depend on any config maps in cluster.