### PR TITLE
Change ORCHESTRATOR to CLOUD_ORCHESTRATOR as it is in vrouter agent

### DIFF
--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -350,7 +350,7 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 			gateway = podList.Items[idx].Annotations["gateway"]
 		}
 		data2["PHYSICAL_INTERFACE"] = physicalInterface
-		data2["ORCHESTRATOR"] = "kubernetes"
+		data2["CLOUD_ORCHESTRATOR"] = "kubernetes"
 		var vrouterConfigBuffer bytes.Buffer
 		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
 			Hostname             string


### PR DESCRIPTION
vRouter does not use ORCHESTRATOR variable in it's scripts - it should be CLOUD_ORCHESTRATOR.