### PR TITLE
Use /usr/local/bin instead of /bin in vrouter containers volumes

### DIFF
--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -291,13 +291,6 @@ func GetDaemonset(cniDir CniDirs) *apps.DaemonSet {
 				},
 			},
 		},
-		core.Volume{Name: "host-bin",
-			VolumeSource: core.VolumeSource{
-				HostPath: &core.HostPathVolumeSource{
-					Path: "/usr/local/bin",
-				},
-			},
-		},
 		core.Volume{
 			Name: "network-scripts",
 			VolumeSource: core.VolumeSource{


### PR DESCRIPTION
On Redhat CoreOS system (used by Openshift) `/bin` is a read only filesystem. Currently pod's of the vrouter daemonset have a volume with hostpath `/bin`. It is mounted to the `/host/bin` directory. This volume is used only by the vrouterkernelinit container, that uses it to copy the `vif` binary to the host. 
https://github.com/Juniper/contrail-container-builder/blob/master/containers/vrouter/kernel-build-init/entrypoint.sh#L44

As one can see by searching for the `/host/bin` path, it is the only place where this path is used.
https://github.com/Juniper/contrail-container-builder/search?q=%2Fhost%2Fbin&unscoped_q=%2Fhost%2Fbin

Because `/bin` is read-only on RHCOS, copying of the vif tool fails and it cannot be used by the vrouter agent container.

This PR changes the volumue mounted to the `/host/bin` directory from the `/bin` volume to the `/usr/local/bin` volume, which is a writable directory on RHCOS.