### PR TITLE
Change /data to /var/lib/zookeeper/data which is not restricted in CoreOS

### DIFF
--- a/pkg/apis/contrail/v1alpha1/zookeeper_types.go
+++ b/pkg/apis/contrail/v1alpha1/zookeeper_types.go
@@ -291,7 +291,7 @@ func (c *Zookeeper) ConfigurationParameters() interface{} {
 	var electionPort int
 	var serverPort int
 	if c.Spec.ServiceConfiguration.Storage.Path == "" {
-		zookeeperConfiguration.Storage.Path = "/data"
+		zookeeperConfiguration.Storage.Path = "/var/lib/zookeeper/data"
 	} else {
 		zookeeperConfiguration.Storage.Path = c.Spec.ServiceConfiguration.Storage.Path
 	}


### PR DESCRIPTION
PR #208 broke Openshift deployment as CoreOS does not allow creating directories in `/`.

In this PR I moved data directory to `/var/lib/zookeeper/data` which is not restricted in CoreOS.