### PR TITLE
Workaround for the zookeeper sts, pv and pvc removal.

### DIFF
--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -165,8 +165,6 @@ spec:
           nodeSelector:
             node-role.kubernetes.io/master: ""
         serviceConfiguration:
-          storage:
-            path: /usr/local/zookeper-data
           containers:
             - name: init
               image: python:alpine

--- a/pkg/apis/contrail/v1alpha1/zookeeper_types.go
+++ b/pkg/apis/contrail/v1alpha1/zookeeper_types.go
@@ -291,7 +291,7 @@ func (c *Zookeeper) ConfigurationParameters() interface{} {
 	var electionPort int
 	var serverPort int
 	if c.Spec.ServiceConfiguration.Storage.Path == "" {
-		zookeeperConfiguration.Storage.Path = "/data"
+		zookeeperConfiguration.Storage.Path = "/var/lib/zookeeper"
 	} else {
 		zookeeperConfiguration.Storage.Path = c.Spec.ServiceConfiguration.Storage.Path
 	}


### PR DESCRIPTION
When using the zookeeper.serviceConfiguration.storage.path field, zookeeper's statefulset, persistent volume and persistent volume claim are removed and created again from time to time. This happens on both Kind and Openshift clusters. On Kind issue was seen after about 50 minutes. Because of the deletion of PV, zookeeper's data is wiped and lost.
More details and logs in the bug ticket: https://contrail-jws.atlassian.net/browse/CEM-16741 

This workaround sets the default path of zookeper's PV to /var/lib/zookeeper (similar to /var/lib/cassandra used by Cassandra's PVs) that can be used on both Kind and Openshift clusters (previous default path: /data couldn't be used on Openshift because of a read-only root dir).

So far I was not able to find the root cause, but because with have a tight deadline, I'm submitting this workaround
