### PR TITLE
Add -f flag to the copy command in vroutercni container to force overwrite

### DIFF
--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -485,9 +485,9 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			command := []string{"sh", "-c",
 				"mkdir -p /host/etc_cni/net.d && " +
 					"mkdir -p /var/lib/contrail/ports/vm && " +
-					"cp /usr/bin/contrail-k8s-cni /host/opt_cni_bin && " +
+					"cp -f /usr/bin/contrail-k8s-cni /host/opt_cni_bin && " +
 					"chmod 0755 /host/opt_cni_bin/contrail-k8s-cni && " +
-					"cp /etc/mycontrail/10-contrail.conf /host/etc_cni/net.d/10-contrail.conf && " +
+					"cp -f /etc/mycontrail/10-contrail.conf /host/etc_cni/net.d/10-contrail.conf && " +
 					"tar -C /host/opt_cni_bin -xzf /opt/cni-v0.3.0.tgz"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {


### PR DESCRIPTION
When contrail version is changed, or the node is restarted and pods are rescheduled again, vroutercni init container has to force overwrite the files created previously. Otherwise, cp command may fail with error:
cp: cannot create regular file '/host/opt_cni_bin/contrail-k8s-cni': Text file busy