### PR TITLE
Added VrouterEncryption and CniMetaPlugin options to vrouter config

### DIFF
--- a/deploy/crds/contrail.juniper.net_managers_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_managers_crd.yaml
@@ -1932,6 +1932,8 @@ spec:
                                 type: string
                               serviceAccount:
                                 type: string
+                              vrouterEncryption:
+                                type: boolean
                             type: object
                         required:
                         - commonConfiguration

--- a/deploy/crds/contrail.juniper.net_managers_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_managers_crd.yaml
@@ -1904,6 +1904,8 @@ spec:
                                 type: string
                               clusterRoleBinding:
                                 type: string
+                              cniMetaPlugin:
+                                type: string
                               containers:
                                 items:
                                   description: Container defines name, image and command.

--- a/deploy/crds/contrail.juniper.net_vrouters_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_vrouters_crd.yaml
@@ -143,6 +143,8 @@ spec:
                   type: string
                 serviceAccount:
                   type: string
+                vrouterEncryption:
+                  type: boolean
               type: object
           required:
           - commonConfiguration

--- a/deploy/crds/contrail.juniper.net_vrouters_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_vrouters_crd.yaml
@@ -115,6 +115,8 @@ spec:
                   type: string
                 clusterRoleBinding:
                   type: string
+                cniMetaPlugin:
+                  type: string
                 containers:
                   items:
                     description: Container defines name, image and command.

--- a/pkg/apis/contrail/v1alpha1/templates/vrouter_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/vrouter_config.go
@@ -54,7 +54,7 @@ var ContrailCNIConfig = template.Must(template.New("").Parse(`{
   "cniVersion": "0.3.1",
   "contrail" : {
       "cluster-name"  : "{{ .KubernetesClusterName }}",
-      "meta-plugin"   : "multus",
+      "meta-plugin"   : "{{ .CniMetaPlugin }}",
       "vrouter-ip"    : "127.0.0.1",
       "vrouter-port"  : 9091,
       "config-dir"    : "/var/lib/contrail/ports/vm",

--- a/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
@@ -51,6 +51,7 @@ func TestVrouterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
+	t.Errorf("%v", environment.vrouterConfigMap2.Data)
 	if environment.vrouterConfigMap.Data["vrouter.1.1.8.1"] != vrouterConfig {
 		configDiff := diff.Diff(environment.vrouterConfigMap.Data["vrouter.1.1.8.1"], vrouterConfig)
 		t.Fatalf("get vrouter config: \n%v\n", configDiff)
@@ -60,6 +61,10 @@ func TestVrouterConfig(t *testing.T) {
 		configDiff := diff.Diff(environment.vrouterConfigMap.Data["10-contrail.conf"], vrouterCniConfig)
 		t.Fatalf("get vrouter cni config: \n%v\n", configDiff)
 	}
+}
+
+func TestVrouterConfigEnvVariablesConfigMap(t *testing.T) {
+
 }
 
 var vrouterConfig = `[CONTROL-NODE]

--- a/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
@@ -35,21 +35,14 @@ func TestVrouterConfig(t *testing.T) {
 	environment := SetupEnv()
 	cl := *environment.client
 
-	err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
-		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"})
-	if err != nil {
+	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
+		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"}); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"},
-		&environment.vrouterConfigMap)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"}, &environment.vrouterConfigMap); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"},
-		&environment.vrouterConfigMap2)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"}, &environment.vrouterConfigMap2); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
 	if environment.vrouterConfigMap.Data["vrouter.1.1.8.1"] != vrouterConfig {
@@ -69,15 +62,11 @@ func TestVrouterDefaultCniConfigValues(t *testing.T) {
 	environment := SetupEnv()
 	cl := *environment.client
 
-	err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
-		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"})
-	if err != nil {
+	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
+		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"}); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"},
-		&environment.vrouterConfigMap)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"}, &environment.vrouterConfigMap); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
 	expectedVrouterCniConfig := `{
@@ -109,15 +98,11 @@ func TestVrouterCustomCniConfigValues(t *testing.T) {
 	cl := *environment.client
 	environment.vrouterResource.Spec.ServiceConfiguration.CniMetaPlugin = "test-meta-plugin"
 
-	err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
-		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"})
-	if err != nil {
+	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
+		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"}); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"},
-		&environment.vrouterConfigMap)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap", Namespace: "default"}, &environment.vrouterConfigMap); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
 	expectedVrouterCniConfig := `{
@@ -148,15 +133,11 @@ func TestVrouterDefaultEnvVariablesConfigMap(t *testing.T) {
 	environment := SetupEnv()
 	cl := *environment.client
 
-	err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
-		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"})
-	if err != nil {
+	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
+		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"}); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"},
-		&environment.vrouterConfigMap2)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"}, &environment.vrouterConfigMap2); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
 
@@ -176,15 +157,11 @@ func TestVrouterCustomEnvVariablesConfigMap(t *testing.T) {
 
 	environment.vrouterResource.Spec.ServiceConfiguration.VrouterEncryption = true
 
-	err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
-		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"})
-	if err != nil {
+	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
+		&environment.vrouterPodList, cl, vrouterClusterInfoFake{clusterName: "test-cluster"}); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
-	err = cl.Get(context.TODO(),
-		types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"},
-		&environment.vrouterConfigMap2)
-	if err != nil {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "vrouter1-vrouter-configmap-1", Namespace: "default"}, &environment.vrouterConfigMap2); err != nil {
 		t.Fatalf("get configmap: (%v)", err)
 	}
 

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -68,6 +68,7 @@ type VrouterConfiguration struct {
 	ClusterRole        string        `json:"clusterRole,omitempty"`
 	ClusterRoleBinding string        `json:"clusterRoleBinding,omitempty"`
 	VrouterEncryption  bool          `json:"vrouterEncryption,omitempty"`
+	CniMetaPlugin      string        `json:"cniMetaPlugin,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -86,6 +87,8 @@ const (
 	CENTOS Distribution = "centos"
 	UBUNTU Distribution = "ubuntu"
 )
+
+const DefaultCniMetaPlugin = "multus"
 
 func init() {
 	SchemeBuilder.Register(&Vrouter{}, &VrouterList{})
@@ -302,11 +305,11 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		return err
 	}
 
-	instanceConfigMapName2 := request.Name + "-" + "vrouter" + "-configmap-1"
-	configMapInstanceDynamicConfig2 := &corev1.ConfigMap{}
+	envVariablesConfigMapName := request.Name + "-" + "vrouter" + "-configmap-1"
+	envVariablesConfigMap := &corev1.ConfigMap{}
 	err = client.Get(context.TODO(),
-		types.NamespacedName{Name: instanceConfigMapName2, Namespace: request.Namespace},
-		configMapInstanceDynamicConfig2)
+		types.NamespacedName{Name: envVariablesConfigMapName, Namespace: request.Namespace},
+		envVariablesConfigMap)
 	if err != nil {
 		return err
 	}
@@ -340,7 +343,7 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	}
 	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
 	var data = make(map[string]string)
-	var data2 = make(map[string]string)
+	var envVariables = make(map[string]string)
 	for idx := range podList.Items {
 		hostname := podList.Items[idx].Annotations["hostname"]
 		physicalInterfaceMac := podList.Items[idx].Annotations["physicalInterfaceMac"]
@@ -357,9 +360,9 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		} else {
 			gateway = podList.Items[idx].Annotations["gateway"]
 		}
-		data2["PHYSICAL_INTERFACE"] = physicalInterface
-		data2["CLOUD_ORCHESTRATOR"] = "kubernetes"
-		data2["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
+		envVariables["PHYSICAL_INTERFACE"] = physicalInterface
+		envVariables["CLOUD_ORCHESTRATOR"] = "kubernetes"
+		envVariables["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
 		var vrouterConfigBuffer bytes.Buffer
 		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
 			Hostname             string
@@ -409,8 +412,10 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		var contrailCNIBuffer bytes.Buffer
 		configtemplates.ContrailCNIConfig.Execute(&contrailCNIBuffer, struct {
 			KubernetesClusterName string
+			CniMetaPlugin         string
 		}{
 			KubernetesClusterName: clusterName,
+			CniMetaPlugin:         vrouterConfig.CniMetaPlugin,
 		})
 		data["10-contrail.conf"] = contrailCNIBuffer.String()
 	}
@@ -419,8 +424,8 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	if err != nil {
 		return err
 	}
-	configMapInstanceDynamicConfig2.Data = data2
-	err = client.Update(context.TODO(), configMapInstanceDynamicConfig2)
+	envVariablesConfigMap.Data = envVariables
+	err = client.Update(context.TODO(), envVariablesConfigMap)
 	if err != nil {
 		return err
 	}
@@ -468,10 +473,13 @@ func (c *Vrouter) ConfigurationParameters() interface{} {
 		vrouterConfiguration.NodeManager = &nodeManager
 	}
 
-	if c.Spec.ServiceConfiguration.VrouterEncryption != false {
-		vrouterConfiguration.VrouterEncryption = true
+	if c.Spec.ServiceConfiguration.CniMetaPlugin != "" {
+		vrouterConfiguration.CniMetaPlugin = c.Spec.ServiceConfiguration.CniMetaPlugin
+	} else {
+		vrouterConfiguration.CniMetaPlugin = DefaultCniMetaPlugin
 	}
 
+	vrouterConfiguration.VrouterEncryption = c.Spec.ServiceConfiguration.VrouterEncryption
 	vrouterConfiguration.PhysicalInterface = physicalInterface
 	vrouterConfiguration.Gateway = gateway
 	vrouterConfiguration.MetaDataSecret = metaDataSecret

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"sort"
+	"strconv"
 
 	configtemplates "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1/templates"
 	"github.com/Juniper/contrail-operator/pkg/certificates"
@@ -66,6 +67,7 @@ type VrouterConfiguration struct {
 	ServiceAccount     string        `json:"serviceAccount,omitempty"`
 	ClusterRole        string        `json:"clusterRole,omitempty"`
 	ClusterRoleBinding string        `json:"clusterRoleBinding,omitempty"`
+	VrouterEncryption  bool          `json:"vrouterEncryption,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -357,6 +359,7 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		}
 		data2["PHYSICAL_INTERFACE"] = physicalInterface
 		data2["CLOUD_ORCHESTRATOR"] = "kubernetes"
+		data2["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
 		var vrouterConfigBuffer bytes.Buffer
 		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
 			Hostname             string
@@ -463,6 +466,10 @@ func (c *Vrouter) ConfigurationParameters() interface{} {
 	} else {
 		nodeManager := true
 		vrouterConfiguration.NodeManager = &nodeManager
+	}
+
+	if c.Spec.ServiceConfiguration.VrouterEncryption != false {
+		vrouterConfiguration.VrouterEncryption = true
 	}
 
 	vrouterConfiguration.PhysicalInterface = physicalInterface


### PR DESCRIPTION
User should be able to configure whether he wants to enable vrouter-vrouter encryption and which cni meta-plugin should be used. This PR adds those two fields to the vrouter service configuration.