### PR TITLE
Change /etc/mycontrail dir name to a more descriptive one

### DIFF
--- a/pkg/apis/contrail/v1alpha1/templates/control_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/control_config.go
@@ -91,7 +91,7 @@ logging {
 // ControlDNSConfig is the template of the Dns service configuration.
 var ControlDNSConfig = template.Must(template.New("").Parse(`[DEFAULT]
 collectors={{ .CollectorServerList }}
-named_config_file = /etc/mycontrail/named.{{ .ListenAddress }}
+named_config_file = /etc/contrailconfigmaps/named.{{ .ListenAddress }}
 named_config_directory = /etc/contrail/dns
 named_log_file = /var/log/contrail/contrail-named.log
 rndc_config_file = contrail-rndc.conf
@@ -161,7 +161,7 @@ sandesh_ca_cert={{ .CAFilePath }}`))
 
 // ControlProvisionConfig is the template of the Control provision script.
 var ControlProvisionConfig = template.Must(template.New("").Parse(`#!/bin/bash
-sed "s/hostip=.*/hostip=${POD_IP}/g" /etc/mycontrail/nodemanager.${POD_IP} > /etc/contrail/contrail-control-nodemgr.conf
+sed "s/hostip=.*/hostip=${POD_IP}/g" /etc/contrailconfigmaps/nodemanager.${POD_IP} > /etc/contrail/contrail-control-nodemgr.conf
 servers=$(echo {{ .APIServerList }} | tr ',' ' ')
 for server in $servers ; do
   python /opt/contrail/utils/provision_control.py --oper $1 \

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -716,7 +716,6 @@ func TestWebuiConfig(t *testing.T) {
 	}
 }
 
-
 func TestCassandraConfig(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 
@@ -1527,7 +1526,7 @@ sandesh_ca_cert=/etc/ssl/certs/kubernetes/ca-bundle.crt`
 
 var dnsConfig = `[DEFAULT]
 collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
-named_config_file = /etc/mycontrail/named.1.1.5.1
+named_config_file = /etc/contrailconfigmaps/named.1.1.5.1
 named_config_directory = /etc/contrail/dns
 named_log_file = /var/log/contrail/contrail-named.log
 rndc_config_file = contrail-rndc.conf
@@ -1631,7 +1630,7 @@ logging {
 };`
 
 var controlProvisioningConfig = `#!/bin/bash
-sed "s/hostip=.*/hostip=${POD_IP}/g" /etc/mycontrail/nodemanager.${POD_IP} > /etc/contrail/contrail-control-nodemgr.conf
+sed "s/hostip=.*/hostip=${POD_IP}/g" /etc/contrailconfigmaps/nodemanager.${POD_IP} > /etc/contrail/contrail-control-nodemgr.conf
 servers=$(echo 1.1.1.1,1.1.1.2,1.1.1.3 | tr ',' ' ')
 for server in $servers ; do
   python /opt/contrail/utils/provision_control.py --oper $1 \
@@ -1710,7 +1709,6 @@ sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.6.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.6.1.crt
 sandesh_ca_cert=/etc/ssl/certs/kubernetes/ca-bundle.crt`
-
 
 var devicemanagerWithFabricConfig = `[DEFAULTS]
 host_ip=2.2.2.2

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -312,7 +312,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 		switch container.Name {
 		case "api":
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-api --conf_file /etc/mycontrail/api.${POD_IP} --conf_file /etc/mycontrail/contrail-keystone-auth.conf --worker_id 0"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-api --conf_file /etc/contrailconfigmaps/api.${POD_IP} --conf_file /etc/contrailconfigmaps/contrail-keystone-auth.conf --worker_id 0"}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -323,7 +323,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -337,10 +337,10 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).VolumeMounts = volumeMountList
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).Image = instanceContainer.Image
 		case "devicemanager":
-			deviceManagerCommand := `/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;
-/usr/bin/rm -f /etc/contrail/contrail-keystone-auth.conf; ln -s /etc/mycontrail/contrail-keystone-auth.conf /etc/contrail/contrail-keystone-auth.conf;
-/usr/bin/rm -f /etc/contrail/contrail-fabric-ansible.conf; ln -s /etc/mycontrail/contrail-fabric-ansible.conf.${POD_IP} /etc/contrail/contrail-fabric-ansible.conf;
-/usr/bin/python /usr/bin/contrail-device-manager --conf_file /etc/mycontrail/devicemanager.${POD_IP} --conf_file /etc/contrail/contrail-keystone-auth.conf
+			deviceManagerCommand := `/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;
+/usr/bin/rm -f /etc/contrail/contrail-keystone-auth.conf; ln -s /etc/contrailconfigmaps/contrail-keystone-auth.conf /etc/contrail/contrail-keystone-auth.conf;
+/usr/bin/rm -f /etc/contrail/contrail-fabric-ansible.conf; ln -s /etc/contrailconfigmaps/contrail-fabric-ansible.conf.${POD_IP} /etc/contrail/contrail-fabric-ansible.conf;
+/usr/bin/python /usr/bin/contrail-device-manager --conf_file /etc/contrailconfigmaps/devicemanager.${POD_IP} --conf_file /etc/contrail/contrail-keystone-auth.conf
 `
 			command := []string{"bash", "-c", deviceManagerCommand}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
@@ -358,7 +358,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -382,8 +382,8 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 		case "dnsmasq":
 			container := &statefulSet.Spec.Template.Spec.Containers[idx]
 			container.Command = []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini;ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;" +
-					"dnsmasq -k -p0 --conf-file=/etc/mycontrail/dnsmasq.${POD_IP}"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini;ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;" +
+					"dnsmasq -k -p0 --conf-file=/etc/contrailconfigmaps/dnsmasq.${POD_IP}"}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command != nil {
 				container.Command = instanceContainer.Command
@@ -397,7 +397,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -436,7 +436,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			container.Image = instanceContainer.Image
 		case "servicemonitor":
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-svc-monitor --conf_file /etc/mycontrail/servicemonitor.${POD_IP} --conf_file /etc/mycontrail/contrail-keystone-auth.conf"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-svc-monitor --conf_file /etc/contrailconfigmaps/servicemonitor.${POD_IP} --conf_file /etc/contrailconfigmaps/contrail-keystone-auth.conf"}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -447,7 +447,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -462,7 +462,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).Image = instanceContainer.Image
 		case "schematransformer":
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-schema --conf_file /etc/mycontrail/schematransformer.${POD_IP}  --conf_file /etc/mycontrail/contrail-keystone-auth.conf"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-schema --conf_file /etc/contrailconfigmaps/schematransformer.${POD_IP}  --conf_file /etc/contrailconfigmaps/contrail-keystone-auth.conf"}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -473,7 +473,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -488,7 +488,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).Image = instanceContainer.Image
 		case "analyticsapi":
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-analytics-api -c /etc/mycontrail/analyticsapi.${POD_IP} -c /etc/mycontrail/contrail-keystone-auth.conf"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini; /usr/bin/python /usr/bin/contrail-analytics-api -c /etc/contrailconfigmaps/analyticsapi.${POD_IP} -c /etc/contrailconfigmaps/contrail-keystone-auth.conf"}
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -499,7 +499,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -516,12 +516,12 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			queryEngineContainer := &statefulSet.Spec.Template.Spec.Containers[idx]
 			queryEngineContainer.Command = []string{"bash", "-c",
-				"/usr/bin/contrail-query-engine --conf_file /etc/mycontrail/queryengine.${POD_IP}"}
+				"/usr/bin/contrail-query-engine --conf_file /etc/contrailconfigmaps/queryengine.${POD_IP}"}
 			volumeMountList := statefulSet.Spec.Template.Spec.Containers[idx].VolumeMounts
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -537,7 +537,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 		case "collector":
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			command := []string{"bash", "-c",
-				"/usr/bin/contrail-collector --conf_file /etc/mycontrail/collector.${POD_IP}"}
+				"/usr/bin/contrail-collector --conf_file /etc/contrailconfigmaps/collector.${POD_IP}"}
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
 			} else {
@@ -547,7 +547,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 				corev1.VolumeMount{
 					Name:      request.Name + "-secret-certificates",
@@ -573,7 +573,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			volumeMountList = append(volumeMountList,
 				corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				},
 			)
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).VolumeMounts = volumeMountList
@@ -582,7 +582,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			if configNodeMgr {
 				instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 				command := []string{"bash", "-c",
-					"sed \"s/hostip=.*/hostip=${POD_IP}/g\" /etc/mycontrail/nodemanagerconfig.${POD_IP} > /etc/contrail/contrail-config-nodemgr.conf; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-config"}
+					"sed \"s/hostip=.*/hostip=${POD_IP}/g\" /etc/contrailconfigmaps/nodemanagerconfig.${POD_IP} > /etc/contrail/contrail-config-nodemgr.conf; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-config"}
 
 				if instanceContainer.Command == nil {
 					(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -593,7 +593,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 				volumeMountList = append(volumeMountList,
 					corev1.VolumeMount{
 						Name:      request.Name + "-" + instanceType + "-volume",
-						MountPath: "/etc/mycontrail",
+						MountPath: "/etc/contrailconfigmaps",
 					},
 				)
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).VolumeMounts = volumeMountList
@@ -603,7 +603,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			if analyticsNodeMgr {
 				instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 				command := []string{"bash", "-c",
-					"sed \"s/hostip=.*/hostip=${POD_IP}/g\" /etc/mycontrail/nodemanageranalytics.${POD_IP} > /etc/contrail/contrail-analytics-nodemgr.conf;/usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-analytics"}
+					"sed \"s/hostip=.*/hostip=${POD_IP}/g\" /etc/contrailconfigmaps/nodemanageranalytics.${POD_IP} > /etc/contrail/contrail-analytics-nodemgr.conf;/usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-analytics"}
 
 				if instanceContainer.Command == nil {
 					(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -614,7 +614,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 				volumeMountList = append(volumeMountList,
 					corev1.VolumeMount{
 						Name:      request.Name + "-" + instanceType + "-volume",
-						MountPath: "/etc/mycontrail",
+						MountPath: "/etc/contrailconfigmaps",
 					},
 				)
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).VolumeMounts = volumeMountList
@@ -624,7 +624,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 		case "statusmonitor":
 			instanceContainer := utils.GetContainerFromList(container.Name, config.Spec.ServiceConfiguration.Containers)
 			command := []string{"sh", "-c",
-				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/mycontrail/monitorconfig.${POD_IP}.yaml"}
+				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/contrailconfigmaps/monitorconfig.${POD_IP}.yaml"}
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
 			} else {
@@ -637,7 +637,7 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{

--- a/pkg/controller/control/control_controller.go
+++ b/pkg/controller/control/control_controller.go
@@ -279,7 +279,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 	for idx, container := range statefulSet.Spec.Template.Spec.Containers {
 		if container.Name == "control" {
 			command := []string{"bash", "-c",
-				"/usr/bin/contrail-control --conf_file /etc/mycontrail/control.${POD_IP}"}
+				"/usr/bin/contrail-control --conf_file /etc/contrailconfigmaps/control.${POD_IP}"}
 			//command = []string{"sh", "-c", "while true; do echo hello; sleep 10;done"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
@@ -294,7 +294,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -312,7 +312,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		if container.Name == "statusmonitor" {
 			command := []string{"sh", "-c",
-				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/mycontrail/monitorconfig.${POD_IP}.yaml"}
+				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/contrailconfigmaps/monitorconfig.${POD_IP}.yaml"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -326,7 +326,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -344,7 +344,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		if container.Name == "named" {
 			command := []string{"bash", "-c",
-				"touch /var/log/contrail/contrail-named.log; chgrp contrail /var/log/contrail/contrail-named.log; chmod g+w /var/log/contrail/contrail-named.log; /usr/bin/contrail-named -f -g -u contrail -c /etc/mycontrail/named.${POD_IP}"}
+				"touch /var/log/contrail/contrail-named.log; chgrp contrail /var/log/contrail/contrail-named.log; chmod g+w /var/log/contrail/contrail-named.log; /usr/bin/contrail-named -f -g -u contrail -c /etc/contrailconfigmaps/named.${POD_IP}"}
 			//command = []string{"sh", "-c", "while true; do echo hello; sleep 10;done"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
@@ -365,7 +365,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -378,7 +378,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		if container.Name == "dns" {
 			command := []string{"bash", "-c",
-				"/usr/bin/contrail-dns --conf_file /etc/mycontrail/dns.${POD_IP}"}
+				"/usr/bin/contrail-dns --conf_file /etc/contrailconfigmaps/dns.${POD_IP}"}
 			//command = []string{"sh", "-c", "while true; do echo hello; sleep 10;done"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
@@ -393,7 +393,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -413,7 +413,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 			if nodemgr {
 
 				command := []string{"bash", "-c",
-					"bash /etc/mycontrail/provision.sh.${POD_IP} add; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-control"}
+					"bash /etc/contrailconfigmaps/provision.sh.${POD_IP} add; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-control"}
 
 				//command = []string{"sh", "-c", "while true; do echo hello; sleep 10;done"}
 				instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
@@ -429,7 +429,7 @@ func (r *ReconcileControl) Reconcile(request reconcile.Request) (reconcile.Resul
 				}
 				volumeMount := corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				}
 				volumeMountList = append(volumeMountList, volumeMount)
 				volumeMount = corev1.VolumeMount{

--- a/pkg/controller/control/sts.go
+++ b/pkg/controller/control/sts.go
@@ -129,7 +129,7 @@ spec:
             preStop:
               exec:
                 command:
-                  - python /etc/mycontrail/deprovision.sh.${POD_IP}
+                  - python /etc/contrailconfigmaps/deprovision.sh.${POD_IP}
           volumeMounts:
             - mountPath: /var/log/contrail
               name: control-logs

--- a/pkg/controller/kubemanager/kubemanager_controller.go
+++ b/pkg/controller/kubemanager/kubemanager_controller.go
@@ -452,7 +452,7 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 	for idx, container := range statefulSet.Spec.Template.Spec.Containers {
 		if container.Name == "kubemanager" {
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/mycontrail/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;/usr/bin/python /usr/bin/contrail-kube-manager -c /etc/mycontrail/kubemanager.${POD_IP}"}
+				"/usr/bin/rm -f /etc/contrail/vnc_api_lib.ini; ln -s /etc/contrailconfigmaps/vnc.${POD_IP} /etc/contrail/vnc_api_lib.ini;/usr/bin/python /usr/bin/contrail-kube-manager -c /etc/contrailconfigmaps/kubemanager.${POD_IP}"}
 			//command = []string{"sh", "-c", "while true; do echo hello; sleep 10;done"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
@@ -467,7 +467,7 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -485,7 +485,7 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 		}
 		if container.Name == "statusmonitor" {
 			command := []string{"sh", "-c",
-				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/mycontrail/monitorconfig.${POD_IP}.yaml"}
+				"/app/statusmonitor/contrail-statusmonitor-image.binary -config /etc/contrailconfigmaps/monitorconfig.${POD_IP}.yaml"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -499,7 +499,7 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -381,7 +381,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 	for idx, container := range daemonSet.Spec.Template.Spec.Containers {
 		if container.Name == "vrouteragent" {
 			command := []string{"bash", "-c",
-				"/entrypoint.sh /usr/bin/contrail-vrouter-agent --config_file /etc/mycontrail/vrouter.${POD_IP}"}
+				"/entrypoint.sh /usr/bin/contrail-vrouter-agent --config_file /etc/contrailconfigmaps/vrouter.${POD_IP}"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&daemonSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -394,7 +394,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -420,7 +420,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 		if container.Name == "nodemanager" {
 			if nodemgr {
 				command := []string{"bash", "-c",
-					"bash /etc/mycontrail/provision.sh.${POD_IP} add; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-vrouter"}
+					"bash /etc/contrailconfigmaps/provision.sh.${POD_IP} add; /usr/bin/python /usr/bin/contrail-nodemgr --nodetype=contrail-vrouter"}
 				instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 				if instanceContainer.Command == nil {
 					(&daemonSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -434,7 +434,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 				}
 				volumeMount := corev1.VolumeMount{
 					Name:      request.Name + "-" + instanceType + "-volume",
-					MountPath: "/etc/mycontrail",
+					MountPath: "/etc/contrailconfigmaps",
 				}
 				volumeMountList = append(volumeMountList, volumeMount)
 				volumeMount = corev1.VolumeMount{
@@ -487,7 +487,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 					"mkdir -p /var/lib/contrail/ports/vm && " +
 					"cp -f /usr/bin/contrail-k8s-cni /host/opt_cni_bin && " +
 					"chmod 0755 /host/opt_cni_bin/contrail-k8s-cni && " +
-					"cp -f /etc/mycontrail/10-contrail.conf /host/etc_cni/net.d/10-contrail.conf && " +
+					"cp -f /etc/contrailconfigmaps/10-contrail.conf /host/etc_cni/net.d/10-contrail.conf && " +
 					"tar -C /host/opt_cni_bin -xzf /opt/cni-v0.3.0.tgz"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
@@ -501,7 +501,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{

--- a/pkg/controller/webui/webui_controller.go
+++ b/pkg/controller/webui/webui_controller.go
@@ -345,9 +345,9 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 	for idx, container := range statefulSet.Spec.Template.Spec.Containers {
 		if container.Name == "webuiweb" {
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/config.global.js; ln -s /etc/mycontrail/config.global.js.${POD_IP} /etc/contrail/config.global.js; /usr/bin/rm -f /etc/contrail/contrail-webui-userauth.js; ln -s /etc/mycontrail/contrail-webui-userauth.js /etc/contrail/contrail-webui-userauth.js; until ss -tulwn |grep LISTEN |grep 6380; do sleep 2; done;/usr/bin/node /usr/src/contrail/contrail-web-core/webServerStart.js --conf_file /etc/contrail/config.global.js"}
+				"/usr/bin/rm -f /etc/contrail/config.global.js; ln -s /etc/contrailconfigmaps/config.global.js.${POD_IP} /etc/contrail/config.global.js; /usr/bin/rm -f /etc/contrail/contrail-webui-userauth.js; ln -s /etc/contrailconfigmaps/contrail-webui-userauth.js /etc/contrail/contrail-webui-userauth.js; until ss -tulwn |grep LISTEN |grep 6380; do sleep 2; done;/usr/bin/node /usr/src/contrail/contrail-web-core/webServerStart.js --conf_file /etc/contrail/config.global.js"}
 
-			//"/certs-init.sh && /usr/bin/node /usr/src/contrail/contrail-web-core/webServerStart.js --conf_file /etc/mycontrail/config.global.js.${POD_IP}"}
+			//"/certs-init.sh && /usr/bin/node /usr/src/contrail/contrail-web-core/webServerStart.js --conf_file /etc/contrailconfigmaps/config.global.js.${POD_IP}"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -360,7 +360,7 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -378,9 +378,9 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 		}
 		if container.Name == "webuijob" {
 			command := []string{"bash", "-c",
-				"/usr/bin/rm -f /etc/contrail/config.global.js; ln -s /etc/mycontrail/config.global.js.${POD_IP} /etc/contrail/config.global.js; /usr/bin/rm -f /etc/contrail/contrail-webui-userauth.js; ln -s /etc/mycontrail/contrail-webui-userauth.js /etc/contrail/contrail-webui-userauth.js; until ss -tulwn |grep LISTEN |grep 6380; do sleep 2; done;/usr/bin/node /usr/src/contrail/contrail-web-core/jobServerStart.js --conf_file /etc/contrail/config.global.js"}
+				"/usr/bin/rm -f /etc/contrail/config.global.js; ln -s /etc/contrailconfigmaps/config.global.js.${POD_IP} /etc/contrail/config.global.js; /usr/bin/rm -f /etc/contrail/contrail-webui-userauth.js; ln -s /etc/contrailconfigmaps/contrail-webui-userauth.js /etc/contrail/contrail-webui-userauth.js; until ss -tulwn |grep LISTEN |grep 6380; do sleep 2; done;/usr/bin/node /usr/src/contrail/contrail-web-core/jobServerStart.js --conf_file /etc/contrail/config.global.js"}
 
-			//"/certs-init.sh && sleep 10;/usr/bin/node /usr/src/contrail/contrail-web-core/jobServerStart.js --conf_file /etc/mycontrail/config.global.js.${POD_IP}"}
+			//"/certs-init.sh && sleep 10;/usr/bin/node /usr/src/contrail/contrail-web-core/jobServerStart.js --conf_file /etc/contrailconfigmaps/config.global.js.${POD_IP}"}
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			if instanceContainer.Command == nil {
 				(&statefulSet.Spec.Template.Spec.Containers[idx]).Command = command
@@ -393,7 +393,7 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			volumeMount = corev1.VolumeMount{
@@ -425,7 +425,7 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			(&statefulSet.Spec.Template.Spec.Containers[idx]).VolumeMounts = volumeMountList


### PR DESCRIPTION
After deployment, user sees two directories on hosts: /etc/contrail and /etc/mycontrail, which may be confusing. Maybe it would be a good idea to change the mycontrail directory to something more descriptive. 

Few ideas:
/etc/contrailconfigmaps
/etc/contrailoperatorconfigs
/etc/contrailoperator