### PR TITLE
Multus contrail configs support

### DIFF
--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -224,6 +224,8 @@ spec:
               image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
               image: pitersk/vrouter-kernel-init
+            - name: multusconfig
+              image: busybox:1.31
     - metadata:
         labels:
           contrail_cluster: cluster1
@@ -251,3 +253,5 @@ spec:
               image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
               image: pitersk/vrouter-kernel-init
+            - name: multusconfig
+              image: busybox:1.31

--- a/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 type vrouterClusterInfoFake struct {
-	clusterName             string
-	cniBinariesDirectory    string
-	cniConfigFilesDirectory string
+	clusterName          string
+	cniBinariesDirectory string
+	deploymentType       string
 }
 
 func (c vrouterClusterInfoFake) KubernetesClusterName() (string, error) {
@@ -25,8 +25,8 @@ func (c vrouterClusterInfoFake) KubernetesClusterName() (string, error) {
 func (c vrouterClusterInfoFake) CNIBinariesDirectory() string {
 	return c.cniBinariesDirectory
 }
-func (c vrouterClusterInfoFake) CNIConfigFilesDirectory() string {
-	return c.cniConfigFilesDirectory
+func (c vrouterClusterInfoFake) DeploymentType() string {
+	return c.deploymentType
 }
 
 func TestVrouterConfig(t *testing.T) {

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -490,5 +490,5 @@ func (c *Vrouter) ConfigurationParameters() interface{} {
 type VrouterClusterInfo interface {
 	KubernetesClusterName() (string, error)
 	CNIBinariesDirectory() string
-	CNIConfigFilesDirectory() string
+	DeploymentType() string
 }

--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -147,9 +147,9 @@ func GetDaemonset(cniDir CniDirs) *apps.DaemonSet {
 				"sh",
 				"-c",
 				"mkdir -p /etc/kubernetes/cni/net.d && " +
-					"cp -f /etc/mycontrail/10-contrail.conf /etc/kubernetes/cni/net.d/10-contrail.conf && " +
+					"cp -f /etc/contrailconfigmaps/10-contrail.conf /etc/kubernetes/cni/net.d/10-contrail.conf && " +
 					"mkdir -p /var/run/multus/cni/net.d && " +
-					"cp -f /etc/mycontrail/10-contrail.conf /var/run/multus/cni/net.d/80-openshift-network.conf"},
+					"cp -f /etc/contrailconfigmaps/10-contrail.conf /var/run/multus/cni/net.d/80-openshift-network.conf"},
 			VolumeMounts: []core.VolumeMount{
 				core.VolumeMount{
 					Name:      "etc-kubernetes-cni",

--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -52,6 +52,28 @@ func GetDaemonset(cniDir CniDirs) *apps.DaemonSet {
 			ImagePullPolicy: "Always",
 		},
 		core.Container{
+			Name: "multusconfig",
+			Image: "busybox",
+			Command: []string{
+				"sh",
+				"-c",
+				"mkdir -p /etc/kubernetes/cni/net.d && " +
+				"cp -f /etc/mycontrail/10-contrail.conf /etc/kubernetes/cni/net.d/10-contrail.conf && " +
+				"mkdir -p /var/run/multus/cni/net.d && " +
+				"cp -f /etc/mycontrail/10-contrail.conf /var/run/multus/cni/net.d/80-openshift-network.conf"},
+			VolumeMounts: []core.VolumeMount{
+				core.VolumeMount{
+					Name:      "etc-kubernetes-cni",
+					MountPath: "/etc/kubernetes/cni",
+				},
+				core.VolumeMount{
+					Name:      "multus-cni",
+					MountPath: "/var/run/multus",
+				},
+			},
+			ImagePullPolicy: "Always",
+		},
+		core.Container{
 			Name:  "nodeinit",
 			Image: "docker.io/michaelhenkel/contrail-node-init:5.2.0-dev1",
 			Env: []core.EnvVar{
@@ -334,6 +356,22 @@ func GetDaemonset(cniDir CniDirs) *apps.DaemonSet {
 			VolumeSource: core.VolumeSource{
 				HostPath: &core.HostPathVolumeSource{
 					Path: "/etc/resolv.conf",
+				},
+			},
+		},
+		core.Volume{
+			Name: "etc-kubernetes-cni",
+			VolumeSource: core.VolumeSource{
+				HostPath: &core.HostPathVolumeSource{
+					Path: "/etc/kubernetes/cni",
+				},
+			},
+		},
+		core.Volume{
+			Name: "multus-cni",
+			VolumeSource: core.VolumeSource{
+				HostPath: &core.HostPathVolumeSource{
+					Path: "/var/run/multus",
 				},
 			},
 		},

--- a/pkg/controller/vrouter/daemonset_test.go
+++ b/pkg/controller/vrouter/daemonset_test.go
@@ -16,9 +16,9 @@ var multusContainer = v1.Container{
 		"sh",
 		"-c",
 		"mkdir -p /etc/kubernetes/cni/net.d && " +
-			"cp -f /etc/mycontrail/10-contrail.conf /etc/kubernetes/cni/net.d/10-contrail.conf && " +
+			"cp -f /etc/contrailconfigmaps/10-contrail.conf /etc/kubernetes/cni/net.d/10-contrail.conf && " +
 			"mkdir -p /var/run/multus/cni/net.d && " +
-			"cp -f /etc/mycontrail/10-contrail.conf /var/run/multus/cni/net.d/80-openshift-network.conf"},
+			"cp -f /etc/contrailconfigmaps/10-contrail.conf /var/run/multus/cni/net.d/80-openshift-network.conf"},
 	VolumeMounts: []v1.VolumeMount{
 		v1.VolumeMount{
 			Name:      "etc-kubernetes-cni",

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -469,8 +469,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).Command = instanceContainer.Command
 		}
 		if container.Name == "vrouterkernelinit" {
-			reqLogger.Info("I detected vrouterkernelinit")
-
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).EnvFrom = []corev1.EnvFromSource{{
 				ConfigMapRef: &corev1.ConfigMapEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -483,8 +481,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 		}
 		if container.Name == "vroutercni" {
-			reqLogger.Info("I detected vroutercni")
-
 			// vroutercni container command is based on the entrypoint.sh script in the contrail-kubernetes-cni-init container
 			command := []string{"sh", "-c",
 				"mkdir -p /host/etc_cni/net.d && " +

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -248,8 +248,8 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	cniDirs := CniDirs{
-		BinariesDirectory:    r.ClusterInfo.CNIBinariesDirectory(),
-		ConfigFilesDirectory: r.ClusterInfo.CNIConfigFilesDirectory(),
+		BinariesDirectory: r.ClusterInfo.CNIBinariesDirectory(),
+		DeploymentType:    r.ClusterInfo.DeploymentType(),
 	}
 
 	daemonSet := GetDaemonset(cniDirs)
@@ -469,6 +469,8 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).Command = instanceContainer.Command
 		}
 		if container.Name == "vrouterkernelinit" {
+			reqLogger.Info("I detected vrouterkernelinit")
+
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).EnvFrom = []corev1.EnvFromSource{{
 				ConfigMapRef: &corev1.ConfigMapEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -481,6 +483,8 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 		}
 		if container.Name == "vroutercni" {
+			reqLogger.Info("I detected vroutercni")
+
 			// vroutercni container command is based on the entrypoint.sh script in the contrail-kubernetes-cni-init container
 			command := []string{"sh", "-c",
 				"mkdir -p /host/etc_cni/net.d && " +
@@ -520,6 +524,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}}
 		}
 		if container.Name == "multusconfig" {
+			reqLogger.Info("I detected multusconfig")
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			volumeMountList := []corev1.VolumeMount{}
 			if len((&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts) > 0 {
@@ -533,7 +538,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts = volumeMountList
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).Image = instanceContainer.Image
 		}
-
 
 	}
 	if err = instance.CreateDS(daemonSet, &instance.Spec.CommonConfiguration, instanceType, request,

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -524,7 +524,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}}
 		}
 		if container.Name == "multusconfig" {
-			reqLogger.Info("I detected multusconfig")
 			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
 			volumeMountList := []corev1.VolumeMount{}
 			if len((&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts) > 0 {
@@ -532,7 +531,7 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 			volumeMount := corev1.VolumeMount{
 				Name:      request.Name + "-" + instanceType + "-volume",
-				MountPath: "/etc/mycontrail",
+				MountPath: "/etc/contrailconfigmaps",
 			}
 			volumeMountList = append(volumeMountList, volumeMount)
 			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts = volumeMountList

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -519,6 +519,21 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 				},
 			}}
 		}
+		if container.Name == "multusconfig" {
+			instanceContainer := utils.GetContainerFromList(container.Name, instance.Spec.ServiceConfiguration.Containers)
+			volumeMountList := []corev1.VolumeMount{}
+			if len((&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts) > 0 {
+				volumeMountList = (&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts
+			}
+			volumeMount := corev1.VolumeMount{
+				Name:      request.Name + "-" + instanceType + "-volume",
+				MountPath: "/etc/mycontrail",
+			}
+			volumeMountList = append(volumeMountList, volumeMount)
+			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).VolumeMounts = volumeMountList
+			(&daemonSet.Spec.Template.Spec.InitContainers[idx]).Image = instanceContainer.Image
+		}
+
 
 	}
 	if err = instance.CreateDS(daemonSet, &instance.Spec.CommonConfiguration, instanceType, request,

--- a/pkg/controller/vrouter/vrouter_controller_test.go
+++ b/pkg/controller/vrouter/vrouter_controller_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 type vrouterClusterInfoFake struct {
-	clusterName             string
-	cniBinariesDirectory    string
-	cniConfigFilesDirectory string
+	clusterName          string
+	cniBinariesDirectory string
+	deploymentType       string
 }
 
 func (c vrouterClusterInfoFake) KubernetesClusterName() (string, error) {
@@ -33,8 +33,8 @@ func (c vrouterClusterInfoFake) KubernetesClusterName() (string, error) {
 func (c vrouterClusterInfoFake) CNIBinariesDirectory() string {
 	return c.cniBinariesDirectory
 }
-func (c vrouterClusterInfoFake) CNIConfigFilesDirectory() string {
-	return c.cniConfigFilesDirectory
+func (c vrouterClusterInfoFake) DeploymentType() string {
+	return c.deploymentType
 }
 
 func TestVrouterController(t *testing.T) {
@@ -116,7 +116,7 @@ func TestVrouterController(t *testing.T) {
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, vrouterCR, controlCR, cassandraCR, configCR)
-	fakeClusterInfo := vrouterClusterInfoFake{"test-cluster", "/cni/bin", "cni/config"}
+	fakeClusterInfo := vrouterClusterInfoFake{"test-cluster", "/cni/bin", "k8s"}
 	reconciler := NewReconciler(fakeClient, scheme, &rest.Config{}, fakeClusterInfo)
 	// when
 	_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: vrouterName})

--- a/pkg/k8s/cluster_info.go
+++ b/pkg/k8s/cluster_info.go
@@ -117,9 +117,9 @@ func (c ClusterConfig) CNIBinariesDirectory() string {
 	return "/opt/cni/bin"
 }
 
-// CNIConfigFilesDirectory returns directory containing CNI config files specific for k8s cluster
-func (c ClusterConfig) CNIConfigFilesDirectory() string {
-	return "/etc/cni"
+// DeploymentType returns deployment type
+func (c ClusterConfig) DeploymentType() string {
+	return "k8s"
 }
 
 type configMap struct {

--- a/pkg/k8s/cluster_info_test.go
+++ b/pkg/k8s/cluster_info_test.go
@@ -96,8 +96,8 @@ func (suite *ClusterInfoSuite) TestCNIBinariesDirectory() {
 	suite.Assert().Equal(suite.VrouterClusterInfo.CNIBinariesDirectory(), "/opt/cni/bin", "Path should be /opt/cni/bin")
 }
 
-func (suite *ClusterInfoSuite) TestCNIConfigFilesDirectory() {
-	suite.Assert().Equal(suite.VrouterClusterInfo.CNIConfigFilesDirectory(), "/etc/cni", "Path should be /etc/cni")
+func (suite *ClusterInfoSuite) TestDeploymentType() {
+	suite.Assert().Equal(suite.VrouterClusterInfo.DeploymentType(), "k8s", "Path should be k8si")
 }
 
 func (suite *ClusterInfoSuite) TestMissingEndpointPort() {

--- a/pkg/openshift/cluster_info.go
+++ b/pkg/openshift/cluster_info.go
@@ -104,7 +104,7 @@ func (c ClusterConfig) CNIBinariesDirectory() string {
 
 // CNIConfigFilesDirectory returns directory containing CNI config files specific for k8s cluster
 func (c ClusterConfig) CNIConfigFilesDirectory() string {
-	return "/etc/kubernetes/cni"
+	return "/etc/cni"
 }
 
 func getInstallConfig(client typedCorev1.CoreV1Interface) (installConfig, error) {

--- a/pkg/openshift/cluster_info.go
+++ b/pkg/openshift/cluster_info.go
@@ -102,9 +102,9 @@ func (c ClusterConfig) CNIBinariesDirectory() string {
 	return "/var/lib/cni/bin"
 }
 
-// CNIConfigFilesDirectory returns directory containing CNI config files specific for k8s cluster
-func (c ClusterConfig) CNIConfigFilesDirectory() string {
-	return "/etc/cni"
+// DeploymentType returns deployment type
+func (c ClusterConfig) DeploymentType() string {
+	return "openshift"
 }
 
 func getInstallConfig(client typedCorev1.CoreV1Interface) (installConfig, error) {

--- a/pkg/openshift/cluster_info_test.go
+++ b/pkg/openshift/cluster_info_test.go
@@ -130,8 +130,8 @@ func (suite *ClusterInfoSuite) TestCNIBinariesDirectory() {
 	suite.Assert().Equal(suite.VrouterClusterInfo.CNIBinariesDirectory(), "/var/lib/cni/bin", "Path should be /var/lib/cni/bin")
 }
 
-func (suite *ClusterInfoSuite) TestCNIConfigFilesDirectory() {
-	suite.Assert().Equal(suite.VrouterClusterInfo.CNIConfigFilesDirectory(), "/etc/kubernetes/cni", "Path should be /etc/kubernetes/cni")
+func (suite *ClusterInfoSuite) TestDeploymentType() {
+	suite.Assert().Equal(suite.VrouterClusterInfo.DeploymentType(), "openshift", "Path should be openshift")
 }
 
 func (suite *ClusterInfoSuite) TestMissingConfigMap() {


### PR DESCRIPTION
For Openshift in order to make Multus work with Contrail there has to be contrail config file in three locations:
- /etc/cni/net.d
- /etc/kubernetes/cni/net.d
- /var/run/multus/cni/net.d

Because bare kubernetes requires config only in /etc/cni/net.d then I removed optional path for config files from cluster info and created alternative container which in openshift dpeloyment will be added to vrouter pod and will copy contrail config to /etc/kubernees/cni/net.d and /var/run/multus/cni/net.d while /etc/cni/net.d will be handled as is used to be in bare kubernetes setup.