### PR TITLE
Add rhel tag to selected images in in openshift manifest

### DIFF
--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -2,7 +2,7 @@
 Deployment depends strongly on Openshift installation which is described in this [documentation](https://docs.openshift.com/container-platform/4.1/installing/installing_aws/installing-aws-customizations.html)
 
 Prerequisities that have to be fulfilled in order to dpeloy Contrail with operator on Openshift:
-* openshift-install binary ([download](https://cloud.redhat.com/openshift/install))
+* openshift-install binary (>=4.4.8) ([download](https://cloud.redhat.com/openshift/install))
 * Openshift pull secrets ([download](https://cloud.redhat.com/openshift/install/pull-secret))
 * Configured AWS account with proper permissions and resolvable base domain configured in Route53 ([documentation](https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html#installing-aws-account))
 * Any SSH key generated on local machine to provide during installation

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -35,6 +35,8 @@ DOCKER_CONFIG=example_json_config
 ```
 Under *CONTRAIL_VERSION* field enter proper Contrail container build tag, available in the hub.juniper.net/contrail-nightly registry.
 
+**NOTE** Do not specify the *-rhel* suffix in the build tag, it will be appended automatically where needed.
+
 *DOCKER_CONFIG* is configuration for registry secret to hub.juniper.net/contrail-nightly
 Set *DOCKER_CONFIG* to registry secret with proper data in base64.
 

--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -43,29 +43,29 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: analyticsapi
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-api:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-api:<CONTRAIL_VERSION>-rhel
             - name: api
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-api:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-api:<CONTRAIL_VERSION>-rhel
             - name: collector
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-collector:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-collector:<CONTRAIL_VERSION>-rhel
             - name: devicemanager
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-rhel
             - name: dnsmasq
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-rhel
             - name: init
               image: python:3.8.2-alpine
             - name: init2
               image: busybox:1.31
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: redis
               image: redis:4.0.2
             - name: schematransformer
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-schema:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-schema:<CONTRAIL_VERSION>-rhel
             - name: servicemonitor
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>-rhel
             - name: queryengine
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-query-engine:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-query-engine:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
               image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:<CONTRAIL_VERSION>
           logLevel: SYS_DEBUG
@@ -85,15 +85,15 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-control:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-control:<CONTRAIL_VERSION>-rhel
             - name: dns
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-dns:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-dns:<CONTRAIL_VERSION>-rhel
             - name: init
               image: python:3.8.2-alpine
             - name: named
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-named:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-named:<CONTRAIL_VERSION>-rhel
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
               image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:<CONTRAIL_VERSION>
           zookeeperInstance: zookeeper1
@@ -146,13 +146,13 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: redis
               image: redis:4.0.2
             - name: webuijob
-              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-job:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-job:<CONTRAIL_VERSION>-rhel
             - name: webuiweb
-              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-web:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-web:<CONTRAIL_VERSION>-rhel
     zookeepers:
     - metadata:
         labels:
@@ -186,9 +186,9 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: kubemanager
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-rhel
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
               image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:<CONTRAIL_VERSION>
           ipFabricForwarding: false
@@ -215,15 +215,15 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: vrouteragent
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:<CONTRAIL_VERSION>-rhel
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-rhel
             - name: vrouterkernelinit
-              image: pitersk/vrouter-kernel-init
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-rhel
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -244,14 +244,14 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:<CONTRAIL_VERSION>-rhel
             - name: vrouteragent
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:<CONTRAIL_VERSION>-rhel
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-rhel
             - name: vrouterkernelinit
-              image: pitersk/vrouter-kernel-init
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-rhel
             - name: multusconfig
               image: busybox:1.31


### PR DESCRIPTION
In this review I add to openshift manifest rhel tag to selected images (all from juniper hub expect for operator, statusmonitor and provisioner - because these are not present with rhel tag) as target version for final release.

Also I changed vrouter kernel init container from private repository to hub juniper image.

Also added information in readme about minimal version of openshift-install binary required.