### PR TITLE
Add script that generate encoded DOCKER_CONFIG for Openshift deployment

### DIFF
--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -43,13 +43,8 @@ Choose source registry for container images with *CONTRAIL_REGISTRY* field.
 *DOCKER_CONFIG* is configuration for registry secret to closed container registry (if registry is wide open then no credentials are required)
 Set *DOCKER_CONFIG* to registry secret with proper data in base64.
 
-**NOTE:** You may create dummy secret on Kind in order to get proper base64 value:
-```
-kubectl create secret docker-registry contrail-registry --docker-server=hub.juniper.net/contrail-nightly --docker-username=<username> --docker-password=<password> --docker-email=<mail for registry> -n contrail
-
-kubect -n contrail get secret contrail-registry -o yaml
-```
-Afterwards, copy the .dockerconfigjson field contents and paste it in the configuration file
+**NOTE:** You may create base64 encoded value for config with script provided in *deploy/openshift/tools/docker-config-generate* directory.
+Copy output of the script and paste into config used to install-manifests script.
 
 4. Modify manifests if neccessary:
 

--- a/deploy/openshift/tools/docker-config-generate/README.md
+++ b/deploy/openshift/tools/docker-config-generate/README.md
@@ -1,0 +1,13 @@
+# DOCKER_CONFIG generate
+
+## What is it?
+This script generates docker config for Contrail Operator install manifests for Openshift encoded in base64 format.
+
+## Encoded format
+
+DOCKER_CONFIG is encoded JSON data in this format:
+`{"auths":{"<registry>":{"username":"<username>","password":"<password>",auth":"<base64 encoded username:password>"}}}`
+
+## Usage
+
+Run script and interactively pass necessary data. Afterwards, copy output and paste into config file for install-manifests script.

--- a/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
+++ b/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+        BASE64_COMMAND='base64'
+else
+        BASE64_COMMAND='base64 -w 0'
+fi
+
 get_parameters() {
     read -p "Docker registry: "  REGISTRY
     read -p "Docker username: "  USERNAME
@@ -7,9 +13,9 @@ get_parameters() {
 }
 
 generate_base64() {
-    AUTH=$(echo $USERNAME:$SECRET | base64 -w 0)
+    AUTH=$(echo $USERNAME:$SECRET | $BASE64_COMMAND)
     RENDERED_JSON=$(echo {\"auths\":{\"${REGISTRY}\":{\"username\": \"${USERNAME}\",\"password\":\"${SECRET}\",\"auth\":\"${AUTH}\"}}})
-    DOCKER_CONFIG=$(echo $RENDERED_JSON | base64 -w 0)
+    DOCKER_CONFIG=$(echo $RENDERED_JSON | $BASE64_COMMAND)
 }
 
 get_parameters

--- a/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
+++ b/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+get_parameters() {
+    read -p "Docker registry: "  REGISTRY
+    read -p "Docker username: "  USERNAME
+    read -s -p "Docker secret: "  SECRET
+}
+
+generate_base64() {
+    AUTH=$(echo $USERNAME:$SECRET | base64 -w 0)
+    RENDERED_JSON=$(echo {\"auths\":{\"${REGISTRY}\":{\"username\": \"${USERNAME}\",\"password\":\"${SECRET}\",\"auth\":\"${AUTH}\"}}})
+    DOCKER_CONFIG=$(echo $RENDERED_JSON | base64 -w 0)
+}
+
+get_parameters
+generate_base64
+
+printf "[INFO] Paste this configuration into install manifests config to provide authentication for contrail-operator.\n"
+printf "\nDOCKER_CONFIG=$DOCKER_CONFIG\n"

--- a/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
+++ b/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 get_parameters() {
     read -p "Docker registry: "  REGISTRY

--- a/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
+++ b/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-        BASE64_COMMAND='base64'
+        BASE64_COMMAND='base64 -w 0'
 else
         BASE64_COMMAND='base64 -w 0'
 fi
@@ -13,9 +13,9 @@ get_parameters() {
 }
 
 generate_base64() {
-    AUTH=$(echo $USERNAME:$SECRET | $BASE64_COMMAND)
-    RENDERED_JSON=$(echo {\"auths\":{\"${REGISTRY}\":{\"username\": \"${USERNAME}\",\"password\":\"${SECRET}\",\"auth\":\"${AUTH}\"}}})
-    DOCKER_CONFIG=$(echo $RENDERED_JSON | $BASE64_COMMAND)
+    AUTH=$(echo -n $USERNAME:$SECRET | $BASE64_COMMAND)
+    RENDERED_JSON=$(echo -n {\"auths\":{\"${REGISTRY}\":{\"username\": \"${USERNAME}\",\"password\":\"${SECRET}\",\"auth\":\"${AUTH}\"}}})
+    DOCKER_CONFIG=$(echo -n $RENDERED_JSON | $BASE64_COMMAND)
 }
 
 get_parameters

--- a/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
+++ b/deploy/openshift/tools/docker-config-generate/generate-docker-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-        BASE64_COMMAND='base64 -w 0'
+        BASE64_COMMAND='base64'
 else
         BASE64_COMMAND='base64 -w 0'
 fi


### PR DESCRIPTION
This short script generates DOCKER_CONFIG which should be provided in config to install-manifests for Openshift