### PR TITLE
Rabbitmq HA failover bug fix

### DIFF
--- a/pkg/apis/contrail/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/contrail/v1alpha1/rabbitmq_types.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -112,10 +111,7 @@ func (c *Rabbitmq) InstanceConfiguration(request reconcile.Request,
 
 	rabbitmqConfigInterface := c.ConfigurationParameters()
 	rabbitmqConfig := rabbitmqConfigInterface.(RabbitmqConfiguration)
-	var rabbitmqNodes string
-	for _, pod := range podList.Items {
-		rabbitmqNodes = rabbitmqNodes + fmt.Sprintf("%s\n", pod.Status.PodIP)
-	}
+
 	var data = make(map[string]string)
 	for _, pod := range podList.Items {
 		rabbitmqConfigString := fmt.Sprintf("listeners.tcp.default = %d\n", *rabbitmqConfig.Port)
@@ -131,8 +127,8 @@ func (c *Rabbitmq) InstanceConfiguration(request reconcile.Request,
 		rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("ssl_options.fail_if_no_peer_cert = true\n")
 		//rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("ssl_options.versions.1 = tlsv1.2\n")
 		rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.peer_discovery_backend = classic_config\n")
-		for nodeNumber, nodeIP := range strings.Fields(rabbitmqNodes) {
-			rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.classic_config.nodes." + strconv.Itoa(nodeNumber+1) + " = rabbit@" + nodeIP + "\n")
+		for podIndex, pod := range podList.Items {
+			rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.classic_config.nodes."+strconv.Itoa(podIndex+1)+" = rabbit@"+pod.Status.PodIP+"\n")
 		}
 		data["rabbitmq-"+pod.Status.PodIP+".conf"] = rabbitmqConfigString
 	}
@@ -145,13 +141,15 @@ func (c *Rabbitmq) InstanceConfiguration(request reconcile.Request,
 	data["RABBITMQ_ENABLED_PLUGINS_FILE"] = "/etc/rabbitmq/plugins.conf"
 
 	configMapInstanceDynamicConfig.Data = data
-
-	configMapInstanceDynamicConfig.Data["rabbitmq.nodes"] = rabbitmqNodes
-	configMapInstanceDynamicConfig.Data["plugins.conf"] = "[rabbitmq_management,rabbitmq_management_agent,rabbitmq_peer_discovery_k8s]."
+	var rabbitmqNodes string
 	for _, pod := range podList.Items {
 		myidString := pod.Name[len(pod.Name)-1:]
 		configMapInstanceDynamicConfig.Data[myidString] = pod.Status.PodIP
+		rabbitmqNodes = rabbitmqNodes + fmt.Sprintf("%s\n", pod.Status.PodIP)
 	}
+
+	configMapInstanceDynamicConfig.Data["rabbitmq.nodes"] = rabbitmqNodes
+	configMapInstanceDynamicConfig.Data["plugins.conf"] = "[rabbitmq_management,rabbitmq_management_agent,rabbitmq_peer_discovery_k8s]."
 
 	var secretName string
 	secret := &corev1.Secret{}

--- a/pkg/apis/contrail/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/contrail/v1alpha1/rabbitmq_types.go
@@ -126,9 +126,11 @@ func (c *Rabbitmq) InstanceConfiguration(request reconcile.Request,
 		rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("ssl_options.verify = verify_peer\n")
 		rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("ssl_options.fail_if_no_peer_cert = true\n")
 		//rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("ssl_options.versions.1 = tlsv1.2\n")
-		rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.peer_discovery_backend = classic_config\n")
-		for podIndex, pod := range podList.Items {
-			rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.classic_config.nodes."+strconv.Itoa(podIndex+1)+" = rabbit@"+pod.Status.PodIP+"\n")
+		if len(podList.Items) > 1 {
+			rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.peer_discovery_backend = classic_config\n")
+			for podIndex, pod := range podList.Items {
+				rabbitmqConfigString = rabbitmqConfigString + fmt.Sprintf("cluster_formation.classic_config.nodes."+strconv.Itoa(podIndex+1)+" = rabbit@"+pod.Status.PodIP+"\n")
+			}
 		}
 		data["rabbitmq-"+pod.Status.PodIP+".conf"] = rabbitmqConfigString
 	}

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -6,7 +6,6 @@ import "text/template"
 var RabbitmqConfig = template.Must(template.New("").Parse(`#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-export RABBITMQ_NODENAME=rabbit@${POD_IP}
 rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
 rabbitmq-server
 `))

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -10,6 +10,7 @@ export RABBITMQ_NODENAME=rabbit@${POD_IP}
 if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
   rabbitmq-server
 else
+rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
   rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
   while [[ $? -ne 0 ]]; do
 	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -10,7 +10,7 @@ export RABBITMQ_NODENAME=rabbit@${POD_IP}
 if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
   rabbitmq-server
 else
-rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
+  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
   rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
   while [[ $? -ne 0 ]]; do
 	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -7,25 +7,8 @@ var RabbitmqConfig = template.Must(template.New("").Parse(`#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
 export RABBITMQ_NODENAME=rabbit@${POD_IP}
-if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
-  rabbitmq-server
-else
-  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  done
-  rabbitmq-server -detached
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  done
-  rabbitmqctl stop_app
-  sleep 2
-  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
-  rabbitmqctl shutdown
-  rabbitmq-server
-fi
+rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+rabbitmq-server
 `))
 
 // RabbitmqDefinition is the template for Rabbitmq user/vhost configuration

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -6,26 +6,8 @@ import "text/template"
 var RabbitmqConfig = template.Must(template.New("").Parse(`#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-export RABBITMQ_NODENAME=rabbit@${POD_IP}
-if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
-  rabbitmq-server
-else
-  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  done
-  rabbitmq-server -detached
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  done
-  rabbitmqctl stop_app
-  sleep 2
-  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
-  rabbitmqctl shutdown
-  rabbitmq-server
-fi
+rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+rabbitmq-server
 `))
 
 // RabbitmqDefinition is the template for Rabbitmq user/vhost configuration

--- a/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/rabbitmq_config.go
@@ -6,8 +6,26 @@ import "text/template"
 var RabbitmqConfig = template.Must(template.New("").Parse(`#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
-rabbitmq-server
+export RABBITMQ_NODENAME=rabbit@${POD_IP}
+if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
+  rabbitmq-server
+else
+  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
+  while [[ $? -ne 0 ]]; do
+	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
+  done
+  rabbitmq-server -detached
+  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
+  while [[ $? -ne 0 ]]; do
+	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
+  done
+  rabbitmqctl stop_app
+  sleep 2
+  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
+  rabbitmqctl shutdown
+  rabbitmq-server
+fi
 `))
 
 // RabbitmqDefinition is the template for Rabbitmq user/vhost configuration

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -1109,26 +1109,8 @@ server.3=1.1.3.3:2888:3888:participant
 var rabbitmqConfigRunner = `#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-export RABBITMQ_NODENAME=rabbit@${POD_IP}
-if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
-  rabbitmq-server
-else
-  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  done
-  rabbitmq-server -detached
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  done
-  rabbitmqctl stop_app
-  sleep 2
-  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
-  rabbitmqctl shutdown
-  rabbitmq-server
-fi
+rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+rabbitmq-server
 `
 
 var rabbitmqConfig = map[string]string{

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -1113,6 +1113,7 @@ export RABBITMQ_NODENAME=rabbit@${POD_IP}
 if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
   rabbitmq-server
 else
+  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
   rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
   while [[ $? -ne 0 ]]; do
 	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
@@ -1141,6 +1142,10 @@ ssl_options.keyfile = /etc/certificates/server-key-1.1.4.1.pem
 ssl_options.certfile = /etc/certificates/server-1.1.4.1.crt
 ssl_options.verify = verify_peer
 ssl_options.fail_if_no_peer_cert = true
+cluster_formation.peer_discovery_backend = classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@1.1.4.1
+cluster_formation.classic_config.nodes.2 = rabbit@1.1.4.2
+cluster_formation.classic_config.nodes.3 = rabbit@1.1.4.3
 `,
 	"rabbitmq-1.1.4.2.conf": `listeners.tcp.default = 5673
 listeners.ssl.default = 15673
@@ -1152,6 +1157,10 @@ ssl_options.keyfile = /etc/certificates/server-key-1.1.4.2.pem
 ssl_options.certfile = /etc/certificates/server-1.1.4.2.crt
 ssl_options.verify = verify_peer
 ssl_options.fail_if_no_peer_cert = true
+cluster_formation.peer_discovery_backend = classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@1.1.4.1
+cluster_formation.classic_config.nodes.2 = rabbit@1.1.4.2
+cluster_formation.classic_config.nodes.3 = rabbit@1.1.4.3
 `,
 	"rabbitmq-1.1.4.3.conf": `listeners.tcp.default = 5673
 listeners.ssl.default = 15673
@@ -1163,6 +1172,10 @@ ssl_options.keyfile = /etc/certificates/server-key-1.1.4.3.pem
 ssl_options.certfile = /etc/certificates/server-1.1.4.3.crt
 ssl_options.verify = verify_peer
 ssl_options.fail_if_no_peer_cert = true
+cluster_formation.peer_discovery_backend = classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@1.1.4.1
+cluster_formation.classic_config.nodes.2 = rabbit@1.1.4.2
+cluster_formation.classic_config.nodes.3 = rabbit@1.1.4.3
 `,
 	"rabbitmq.nodes":         fmt.Sprintf("1.1.4.1\n1.1.4.2\n1.1.4.3\n"),
 	"0":                      "1.1.4.1",
@@ -1174,7 +1187,7 @@ ssl_options.fail_if_no_peer_cert = true
 	"RABBITMQ_PID_FILE":      "/var/run/rabbitmq.pid",
 	"RABBITMQ_CONF_ENV_FILE": "/var/lib/rabbitmq/rabbitmq.env",
 	"definitions.json":       rabbitmqDefinition,
-	"plugins.conf":           "[rabbitmq_management,rabbitmq_management_agent].",
+	"plugins.conf":           "[rabbitmq_management,rabbitmq_management_agent,rabbitmq_peer_discovery_k8s].",
 }
 
 var rabbitmqDefinition = `{

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -1110,25 +1110,8 @@ var rabbitmqConfigRunner = `#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
 export RABBITMQ_NODENAME=rabbit@${POD_IP}
-if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
-  rabbitmq-server
-else
-  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
-  done
-  rabbitmq-server -detached
-  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  while [[ $? -ne 0 ]]; do
-	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
-  done
-  rabbitmqctl stop_app
-  sleep 2
-  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
-  rabbitmqctl shutdown
-  rabbitmq-server
-fi
+rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+rabbitmq-server
 `
 
 var rabbitmqConfig = map[string]string{

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -1109,7 +1109,6 @@ server.3=1.1.3.3:2888:3888:participant
 var rabbitmqConfigRunner = `#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-export RABBITMQ_NODENAME=rabbit@${POD_IP}
 rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
 rabbitmq-server
 `

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -1109,8 +1109,26 @@ server.3=1.1.3.3:2888:3888:participant
 var rabbitmqConfigRunner = `#!/bin/bash
 echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
 chmod 0600 /var/lib/rabbitmq/.erlang.cookie
-rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
-rabbitmq-server
+export RABBITMQ_NODENAME=rabbit@${POD_IP}
+if [[ $(grep $POD_IP /etc/rabbitmq/0) ]] ; then
+  rabbitmq-server
+else
+  rabbitmqctl --node rabbit@${POD_IP} forget_cluster_node rabbit@${POD_IP}
+  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
+  while [[ $? -ne 0 ]]; do
+	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) ping
+  done
+  rabbitmq-server -detached
+  rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
+  while [[ $? -ne 0 ]]; do
+	rabbitmqctl --node rabbit@$(cat /etc/rabbitmq/0) node_health_check
+  done
+  rabbitmqctl stop_app
+  sleep 2
+  rabbitmqctl join_cluster rabbit@$(cat /etc/rabbitmq/0)
+  rabbitmqctl shutdown
+  rabbitmq-server
+fi
 `
 
 var rabbitmqConfig = map[string]string{

--- a/pkg/controller/cassandra/cassandra_controller.go
+++ b/pkg/controller/cassandra/cassandra_controller.go
@@ -434,7 +434,7 @@ func (r *ReconcileCassandra) Reconcile(request reconcile.Request) (reconcile.Res
 	volumeBindingMode := storagev1.VolumeBindingMode("WaitForFirstConsumer")
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "local-storage",
+			Name: "local-storage",
 		},
 		Provisioner:       "kubernetes.io/no-provisioner",
 		VolumeBindingMode: &volumeBindingMode,
@@ -479,7 +479,7 @@ func (r *ReconcileCassandra) Reconcile(request reconcile.Request) (reconcile.Res
 	for i := 0; i < replicasInt; i++ {
 		pv := &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      instance.Name + "-pv-" + strconv.Itoa(i),
+				Name: instance.Name + "-pv-" + strconv.Itoa(i),
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				Capacity:   corev1.ResourceList{storageResource: diskSize},

--- a/pkg/controller/rabbitmq/BUILD.bazel
+++ b/pkg/controller/rabbitmq/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/certificates:go_default_library",
         "//pkg/controller/utils:go_default_library",
         "//pkg/randomstring:go_default_library",
-        "@com_github_ghodss//:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/controller/rabbitmq/sts.go
+++ b/pkg/controller/rabbitmq/sts.go
@@ -65,13 +65,6 @@ spec:
           name: rabbitmq-data
         - mountPath: /var/log/rabbitmq
           name: rabbitmq-logs
-        lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - "export RABBITMQ_NODENAME=rabbit@${POD_IP}; rabbitmqctl stop_app; rabbitmqctl reset"
         readinessProbe:
           exec:
             command:

--- a/pkg/controller/rabbitmq/sts.go
+++ b/pkg/controller/rabbitmq/sts.go
@@ -1,111 +1,189 @@
 package rabbitmq
 
 import (
-	"github.com/ghodss/yaml"
-	appsv1 "k8s.io/api/apps/v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var yamlRabbitmq_sts = `
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: rabbitmq
-spec:
-  selector:
-    matchLabels:
-      app: rabbitmq
-  serviceName: "rabbitmq"
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: rabbitmq
-        contrail_manager: rabbitmq
-    spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ''
-      tolerations:
-      - operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoExecute
-      hostNetwork: true
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - until grep ready /tmp/podinfo/pod_labels > /dev/null 2>&1; do sleep 1; done
-        image: busybox
-        imagePullPolicy: Always
-        name: init
-        resources: {}
-        securityContext:
-          privileged: false
-          procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /tmp/podinfo
-          name: status
-      containers:
-      - name: rabbitmq
-        env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        image: docker.io/michaelhenkel/contrail-external-rabbitmq:5.2.0-dev1
-        imagePullPolicy: ""
-        volumeMounts:
-        - mountPath: /var/lib/rabbitmq
-          name: rabbitmq-data
-        - mountPath: /var/log/rabbitmq
-          name: rabbitmq-logs
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - "export RABBITMQ_NODENAME=rabbit@$POD_IP; cluster_status=$(rabbitmqctl cluster_status);nodes=$(echo $cluster_status | sed -e 's/.*disc,\\[\\(.*\\)]}]}, {.*/\\1/' | grep -oP \"(?<=rabbit@).*?(?=')\"); for node in $(cat /etc/rabbitmq/rabbitmq.nodes); do echo ${nodes} |grep ${node}; if [[ $? -ne 0 ]]; then exit -1; fi; done"
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-      volumes:
-      - name: rabbitmq-data
-        hostPath:
-          path: /var/lib/contrail/rabbitmq
-      - name: rabbitmq-logs
-        hostPath:
-          path: /var/log/contrail/rabbitmq
-      - downwardAPI:
-          defaultMode: 420
-          items:
-          - fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.labels
-            path: pod_labels
-          - fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.labels
-            path: pod_labelsx
-        name: status`
+func GetSTS() *apps.StatefulSet {
+	var replicas = int32(1)
+	var labelsMountPermission int32 = 0644
 
-func GetSTS() *appsv1.StatefulSet {
-	sts := appsv1.StatefulSet{}
-	err := yaml.Unmarshal([]byte(yamlRabbitmq_sts), &sts)
-	if err != nil {
-		panic(err)
+	var podIPEnv = core.EnvVar{
+		Name: "POD_IP",
+		ValueFrom: &core.EnvVarSource{
+			FieldRef: &core.ObjectFieldSelector{
+				FieldPath: "status.podIP",
+			},
+		},
 	}
-	jsonData, err := yaml.YAMLToJSON([]byte(yamlRabbitmq_sts))
-	if err != nil {
-		panic(err)
+
+	var podInitContainers = []core.Container{
+		{
+			Name:  "init",
+			Image: "busybox",
+			Command: []string{
+				"sh",
+				"-c",
+				"until grep ready /tmp/podinfo/pod_labels > /dev/null 2>&1; do sleep 1; done",
+			},
+			Env: []core.EnvVar{
+				podIPEnv,
+			},
+			VolumeMounts: []core.VolumeMount{
+				core.VolumeMount{
+					Name:      "status",
+					MountPath: "/tmp/podinfo",
+				},
+			},
+			ImagePullPolicy:          "Always",
+			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePolicy: core.TerminationMessageReadFile,
+		},
 	}
-	err = yaml.Unmarshal([]byte(jsonData), &sts)
-	if err != nil {
-		panic(err)
+
+	var podContainers = []core.Container{
+		{
+			Name:  "rabbitmq",
+			Image: "docker.io/michaelhenkel/contrail-external-rabbitmq:5.2.0-dev1",
+			VolumeMounts: []core.VolumeMount{
+				{
+					Name:      "rabbitmq-data",
+					MountPath: "/var/lib/rabbitmq",
+				},
+				{
+					Name:      "rabbitmq-logs",
+					MountPath: "/var/log/rabbitmq",
+				},
+			},
+			Env: []core.EnvVar{
+				{
+					Name: "POD_IP",
+					ValueFrom: &core.EnvVarSource{
+						FieldRef: &core.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				},
+				{
+					Name: "POD_NAME",
+					ValueFrom: &core.EnvVarSource{
+						FieldRef: &core.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+			},
+			ReadinessProbe: &core.Probe{
+				InitialDelaySeconds: 15,
+				TimeoutSeconds:      5,
+				Handler: core.Handler{
+					Exec: &core.ExecAction{
+						Command: []string{
+							"/bin/bash",
+							"-c",
+							"export RABBITMQ_NODENAME=rabbit@$POD_IP; cluster_status=$(rabbitmqctl cluster_status);nodes=$(echo $cluster_status | sed -e 's/.*disc,\\[\\(.*\\)]}]}, {.*/\\1/' | grep -oP \"(?<=rabbit@).*?(?=')\"); for node in $(cat /etc/rabbitmq/rabbitmq.nodes); do echo ${nodes} |grep ${node}; if [[ $? -ne 0 ]]; then exit -1; fi; done",
+						},
+					},
+				},
+			},
+		},
 	}
-	return &sts
+
+	var podVolumes = []core.Volume{
+		{
+			Name: "rabbitmq-data",
+			VolumeSource: core.VolumeSource{
+				HostPath: &core.HostPathVolumeSource{
+					Path: "/var/lib/contrail/rabbitmq",
+				},
+			},
+		},
+		{
+			Name: "rabbitmq-logs",
+			VolumeSource: core.VolumeSource{
+				HostPath: &core.HostPathVolumeSource{
+					Path: "/var/log/contrail/rabbitmq",
+				},
+			},
+		},
+		{
+			Name: "status",
+			VolumeSource: core.VolumeSource{
+				DownwardAPI: &core.DownwardAPIVolumeSource{
+					Items: []core.DownwardAPIVolumeFile{
+						core.DownwardAPIVolumeFile{
+							Path: "pod_labels",
+							FieldRef: &core.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.labels",
+							},
+						},
+						core.DownwardAPIVolumeFile{
+							Path: "pod_labelsx",
+							FieldRef: &core.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.labels",
+							},
+						},
+					},
+					DefaultMode: &labelsMountPermission,
+				},
+			},
+		},
+	}
+
+	var podTolerations = []core.Toleration{
+		core.Toleration{
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		core.Toleration{
+			Operator: "Exists",
+			Effect:   "NoExecute",
+		},
+	}
+
+	var podSpec = core.PodSpec{
+		Volumes:        podVolumes,
+		InitContainers: podInitContainers,
+		Containers:     podContainers,
+		RestartPolicy:  "Always",
+		DNSPolicy:      "ClusterFirst",
+		HostNetwork:    true,
+		Tolerations:    podTolerations,
+		NodeSelector:   map[string]string{"node-role.kubernetes.io/master": ""},
+	}
+
+	var stsTemplate = core.PodTemplateSpec{
+		ObjectMeta: meta.ObjectMeta{
+			Labels: map[string]string{
+				"app":              "rabbitmq",
+				"contrail_manager": "rabbitmq",
+			},
+		},
+		Spec: podSpec,
+	}
+
+	var stsSelector = meta.LabelSelector{
+		MatchLabels: map[string]string{"app": "rabbitmq"},
+	}
+
+	return &apps.StatefulSet{
+		TypeMeta: meta.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "rabbitmq",
+			Namespace: "default",
+		},
+		Spec: apps.StatefulSetSpec{
+			Selector:    &stsSelector,
+			ServiceName: "rabbitmq",
+			Replicas:    &replicas,
+			Template:    stsTemplate,
+		},
+	}
 }

--- a/pkg/controller/rabbitmq/sts.go
+++ b/pkg/controller/rabbitmq/sts.go
@@ -65,6 +65,13 @@ spec:
           name: rabbitmq-data
         - mountPath: /var/log/rabbitmq
           name: rabbitmq-logs
+        lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "export RABBITMQ_NODENAME=rabbit@${POD_IP}; rabbitmqctl stop_app; rabbitmqctl reset"
         readinessProbe:
           exec:
             command:

--- a/pkg/controller/rabbitmq/sts.go
+++ b/pkg/controller/rabbitmq/sts.go
@@ -65,13 +65,6 @@ spec:
           name: rabbitmq-data
         - mountPath: /var/log/rabbitmq
           name: rabbitmq-logs
-        lifecycle:
-          preStop:
-            exec:
-              command: 
-              - /bin/sh
-              - -c
-              - "export RABBITMQ_NODENAME=rabbit@${POD_IP}; rabbitmqctl stop_app; rabbitmqctl reset"
         readinessProbe:
           exec:
             command:

--- a/test/e2e/ha/scale_core_contrail_services_test.go
+++ b/test/e2e/ha/scale_core_contrail_services_test.go
@@ -229,7 +229,6 @@ func TestHACoreContrailServices(t *testing.T) {
 		}
 
 		t.Run("when manager resource with Config and dependencies are created", func(t *testing.T) {
-			t.Skip()
 			var replicas int32 = 1
 			_, err := controllerutil.CreateOrUpdate(context.Background(), f.Client.Client, cluster, func() error {
 				cluster.Spec.CommonConfiguration.Replicas = &replicas

--- a/test/e2e/ha/scale_core_contrail_services_test.go
+++ b/test/e2e/ha/scale_core_contrail_services_test.go
@@ -229,6 +229,7 @@ func TestHACoreContrailServices(t *testing.T) {
 		}
 
 		t.Run("when manager resource with Config and dependencies are created", func(t *testing.T) {
+			t.Skip()
 			var replicas int32 = 1
 			_, err := controllerutil.CreateOrUpdate(context.Background(), f.Client.Client, cluster, func() error {
 				cluster.Spec.CommonConfiguration.Replicas = &replicas


### PR DESCRIPTION
This PR fix bug where after node reboot, rabbitmq pod on rebooted node does not join cluster of other rabbitmqs.
I added cluster formation plugin which is configured with classic config to enable auto join to cluster (https://www.rabbitmq.com/cluster-formation.html#peer-discovery-classic-config).

Each rabbitmq has cluster nodes specified in config so when there's reboot it'll automatically join cluster.
Moreover, as described in documentation, to prevent situation where pod will not be able to join cluster because it'll have old data and during it's reboot some other changes happened to cluster I added to command run in pod `rabbitmqctl forget_cluster_node` which will ensure that pod will not try to join with old configuration and new session will be established.

I see that there's also an option to configure this plugin especially for k8s where peer discovery is done via k8s cluster, but it'd require some more changes in architecture of how we handle rabbitmq pods and since this bug is for R2008 then I'll just create improvement ticket for migration to k8s cluster peer discovery and this PR will be solution for R2008.
