### PR TITLE
Cassandra readiness probe

### DIFF
--- a/pkg/apis/contrail/v1alpha1/cassandra_types.go
+++ b/pkg/apis/contrail/v1alpha1/cassandra_types.go
@@ -244,17 +244,13 @@ func (c *Cassandra) SetInstanceActive(client client.Client, activeStatus *bool, 
 		sts); err != nil {
 		return err
 	}
-	active := false
+	*activeStatus = false
 	var acceptableReadyReplicaCnt = *sts.Spec.Replicas/2 + 1
 	if sts.Status.ReadyReplicas >= acceptableReadyReplicaCnt {
-		active = true
+		*activeStatus = true
 	}
 
-	*activeStatus = active
-	if err := client.Status().Update(context.TODO(), c); err != nil {
-		return err
-	}
-	return nil
+	return client.Status().Update(context.TODO(), c)
 }
 
 // ManageNodeStatus manages the status of the Cassandra nodes.

--- a/pkg/apis/contrail/v1alpha1/cassandra_types.go
+++ b/pkg/apis/contrail/v1alpha1/cassandra_types.go
@@ -240,7 +240,21 @@ func (c *Cassandra) PodIPListAndIPMapFromInstance(instanceType string, request r
 
 // SetInstanceActive sets the Cassandra instance to active.
 func (c *Cassandra) SetInstanceActive(client client.Client, activeStatus *bool, sts *appsv1.StatefulSet, request reconcile.Request) error {
-	return SetInstanceActive(client, activeStatus, sts, request, c)
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: sts.Name, Namespace: request.Namespace},
+		sts); err != nil {
+		return err
+	}
+	active := false
+	var acceptableReadyReplicaCnt = *sts.Spec.Replicas/2 + 1
+	if sts.Status.ReadyReplicas >= acceptableReadyReplicaCnt {
+		active = true
+	}
+
+	*activeStatus = active
+	if err := client.Status().Update(context.TODO(), c); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ManageNodeStatus manages the status of the Cassandra nodes.

--- a/pkg/controller/cassandra/sts.go
+++ b/pkg/controller/cassandra/sts.go
@@ -45,7 +45,7 @@ spec:
             command:
             - /bin/bash
             - -c
-            - "seeds=$(for i in $(ls /mydata/*.yaml); do echo $(basename $i .yaml); done) &&  for seed in $(echo $seeds); do if [[ $(nodetool status | grep $seed |awk '{print $1}') != 'UN' ]]; then exit -1; fi; done"
+            - "if [[ $(nodetool status | grep ${POD_IP} |awk '{print $1}') != 'UN' ]]; then exit -1; fi;"
           initialDelaySeconds: 15
           timeoutSeconds: 5
         name: cassandra


### PR DESCRIPTION
Changed Cassandra readiness probe to check only one Cassandra instance running in a current pod.

Casandra cluster is active when at least the number of ready pods is more than half of desired.