### PR TITLE
Set introspect_ssl_insecure to true in every config file

### DIFF
--- a/pkg/apis/contrail/v1alpha1/templates/config_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/config_config.go
@@ -72,7 +72,7 @@ rabbit_health_check_interval=10
 collectors={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -116,7 +116,7 @@ collectors={{ .CollectorServerList }}
 dm_run_mode={{ .DMRunMode }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -147,7 +147,7 @@ collectors={{ .CollectorServerList }}
 
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -192,7 +192,7 @@ rabbit_health_check_interval=10
 collectors={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -245,7 +245,7 @@ analytics_server_list={{ .AnalyticsServerList }}
 aaa_mode={{ .AAAMode }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -279,7 +279,7 @@ redis_uve_list={{ .RedisServerList }}
 redis_password=
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -343,7 +343,7 @@ rabbitmq_ssl_ca_certs={{ .CAFilePath }}
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -376,6 +376,7 @@ password=
 redis_ssl_enable=False
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -395,7 +396,7 @@ db_use_ssl=true
 server_list={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt
@@ -415,6 +416,7 @@ db_use_ssl=true
 server_list={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .HostIP }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .HostIP }}.crt

--- a/pkg/apis/contrail/v1alpha1/templates/control_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/control_config.go
@@ -46,6 +46,7 @@ rabbitmq_ssl_ca_certs={{ .CAFilePath }}
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt
@@ -134,6 +135,7 @@ rabbitmq_ssl_ca_certs={{ .CAFilePath }}
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt
@@ -153,7 +155,7 @@ db_use_ssl=True
 server_list={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt

--- a/pkg/apis/contrail/v1alpha1/templates/kubemanager_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/kubemanager_config.go
@@ -47,7 +47,7 @@ collectors={{ .CollectorServerList }}
 zk_server_ip={{ .ZookeeperServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt

--- a/pkg/apis/contrail/v1alpha1/templates/vrouter_config.go
+++ b/pkg/apis/contrail/v1alpha1/templates/vrouter_config.go
@@ -22,7 +22,7 @@ physical_interface_mac = {{ .PhysicalInterfaceMac }}
 tsn_servers = []
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt
@@ -81,7 +81,7 @@ db_use_ssl=False
 server_list={{ .CollectorServerList }}
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-{{ .ListenAddress }}.pem
 sandesh_certfile=/etc/certificates/server-{{ .ListenAddress }}.crt

--- a/pkg/apis/contrail/v1alpha1/tests/config_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_test.go
@@ -962,7 +962,7 @@ rabbit_health_check_interval=10
 collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1252,7 +1252,7 @@ collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 dm_run_mode=Full
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1294,7 +1294,7 @@ rabbit_health_check_interval=10
 collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1346,7 +1346,7 @@ analytics_server_list=1.1.1.1:8081 1.1.1.2:8081 1.1.1.3:8081
 aaa_mode=rbac
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1378,6 +1378,7 @@ password=
 redis_ssl_enable=False
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1410,7 +1411,7 @@ redis_uve_list=1.1.1.1:6379 1.1.1.2:6379 1.1.1.3:6379
 redis_password=
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1473,7 +1474,7 @@ rabbitmq_ssl_ca_certs=/etc/ssl/certs/kubernetes/ca-bundle.crt
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt
@@ -1532,6 +1533,7 @@ rabbitmq_ssl_ca_certs=/etc/ssl/certs/kubernetes/ca-bundle.crt
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.5.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.5.1.crt
@@ -1582,6 +1584,7 @@ rabbitmq_ssl_ca_certs=/etc/ssl/certs/kubernetes/ca-bundle.crt
 rabbitmq_ssl_version=tlsv1_2
 [SANDESH]
 introspect_ssl_enable=True
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.5.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.5.1.crt
@@ -1600,7 +1603,7 @@ db_use_ssl=True
 server_list=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.5.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.5.1.crt
@@ -1717,7 +1720,7 @@ collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 zk_server_ip=1.1.3.1:2181,1.1.3.2:2181,1.1.3.3:2181
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.6.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.6.1.crt
@@ -1760,7 +1763,7 @@ collectors=1.1.1.1:8086 1.1.1.2:8086 1.1.1.3:8086
 dm_run_mode=Full
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.1.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.1.1.crt

--- a/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
@@ -194,7 +194,7 @@ physical_interface_mac = de:ad:be:ef:ba:be
 tsn_servers = []
 [SANDESH]
 introspect_ssl_enable=True
-introspect_ssl_insecure=False
+introspect_ssl_insecure=True
 sandesh_ssl_enable=True
 sandesh_keyfile=/etc/certificates/server-key-1.1.8.1.pem
 sandesh_certfile=/etc/certificates/server-1.1.8.1.crt


### PR DESCRIPTION
All config files were adjusted to handle insecure requests.
After changes tested on control container:
```
(control-control)[root@kind-control-plane /]$ curl https://127.0.0.1:8083 -k
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head><link href="css/style.css" rel="stylesheet" type="text/css"/><title>contrail-control</title></head><body>
<h1>Modules for contrail-control</h1>
<a href="bgp_peer.xml">bgp_peer.xml</a><br/>
<a href="cpuinfo.xml">cpuinfo.xml</a><br/>
<a href="ifmap_log.xml">ifmap_log.xml</a><br/>
<a href="ifmap_server_show.xml">ifmap_server_show.xml</a><br/>
<a href="nodeinfo.xml">nodeinfo.xml</a><br/>
<a href="process_info.xml">process_info.xml</a><br/>
<a href="route_aggregate.xml">route_aggregate.xml</a><br/>
<a href="routing_instance_analytics.xml">routing_instance_analytics.xml</a><br/>
<a href="routing_policy.xml">routing_policy.xml</a><br/>
<a href="routing_table.xml">routing_table.xml</a><br/>
<a href="sandesh_trace.xml">sandesh_trace.xml</a><br/>
<a href="sandesh_uve.xml">sandesh_uve.xml</a><br/>
<a href="service_chaining.xml">service_chaining.xml</a><br/>
<a href="static_route.xml">static_route.xml</a><br/>
<a href="task.xml">task.xml</a><br/>
<a href="version.xml">version.xml</a><br/>
<a href="xmpp_server.xml">xmpp_server.xml</a><br/>
</body></html>
```