### PR TITLE
Disable devicemanager and dnsmasq for Openshift deployment

### DIFF
--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -50,8 +50,16 @@ spec:
               image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>-rhel
             - name: devicemanager
               image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-rhel
+              command:
+                - "/bin/sh"
+                - "-c"
+                - "tail -f /dev/null"
             - name: dnsmasq
               image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-rhel
+              command:
+                - "/bin/sh"
+                - "-c"
+                - "tail -f /dev/null"
             - name: init
               image: python:3.8.2-alpine
             - name: init2


### PR DESCRIPTION
Because of frequent errors on QA setup this is PR that disables devicemanager and dnsmasq in config component