### PR TITLE
Add node selector and affinity to operator deployment

### DIFF
--- a/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
@@ -31,6 +31,10 @@ spec:
       - name: contrail-registry
       tolerations:
         - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 2
+        - effect: NoExecute
           operator: Exists
         - effect: NoSchedule
           operator: Exists

--- a/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: contrail-operator
   namespace: contrail
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: contrail-operator
@@ -13,6 +13,18 @@ spec:
       labels:
         name: contrail-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: name
+                  operator: In
+                  values:
+                  - "contrail-operator"
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       serviceAccountName: contrail-operator
       hostNetwork: true
       imagePullSecrets:

--- a/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-08-operator.yaml
@@ -31,10 +31,6 @@ spec:
       - name: contrail-registry
       tolerations:
         - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-          tolerationSeconds: 2
-        - effect: NoExecute
           operator: Exists
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
This change will create operator pods only on master nodes spreading them to different nodes in case one fails.
Also this PR sets replicas of operator pods to 3 which means that it enables HA of operators in case one pod will become unavailable.