### PR TITLE
Operator leader election with lease time

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
 	"runtime"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	_ "github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
@@ -78,20 +76,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.TODO()
-
-	// Become the leader before proceeding.
-	err = leader.Become(ctx, "contrail-manager-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	// Create a new Cmd to provide shared dependencies and start components.
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: "0",
+		LeaderElection:     true,
+		LeaderElectionID:   "contrail-manager-lock",
 	})
 	if err != nil {
 		log.Error(err, "")


### PR DESCRIPTION
To make operator highly available, current leader election (so called Leader For Life) algorithm has to be changed. Its high availability depends on the --pod-eviction-timeout setting in the kube-controller-manager. Its default value is set to 5 minutes and in some environments, like Openshift, we cannot modify it.

Operator sdk's manager uses  a leader election with lease time algorithm by default. Description here:
https://github.com/operator-framework/operator-sdk/blob/master/website/content/en/docs/building-operators/golang/advanced-topics.md#leader-election

With that in place, leader has to renew the lock (configmap) every 15 seconds (default value). Once the node with the leader goes down, and the lock hasn't been renewed, some other pod on a working node will take over.
