### PR TITLE
Add goimports check to nogo linter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ nogo(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/analysis/gofmt:go_tool_library",
+        "//pkg/analysis/goimports:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/asmdecl:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/assign:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/atomicalign:go_tool_library",

--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ System tests can be run using operator-sdk tool
     # To run ha e2e test
     operator-sdk test local ./test/e2e/ha/ --namespace contrail --go-test-flags "-v -timeout=30m" --up-local
 
+## Before submitting pull request
+
+There is a set of tools that can check your code automatically. This includes static code checks, unit-tests and e2e integration tests. Most of those checks are run for every pull request and vote.
+
+### Run gazelle to make sure that all BUILD.bazel files get updated
+
+    bazel run //:gazelle
+
+### Build and test code. This commands also runs `nogo` linters
+
+    bazel build //... && bazel test //...
+
+It will report errors in case:
+
+* code doesn't build
+* unit-tests fails
+* static checks don't pass
+* code is not correctly formatted
+
 ## Notes
 
 * Contrail Operator creates Persistent Volumes that are used by some of the deployed pods. After deletion of Contrail resources (e.g. after deleting the Manager Custom Resource), those Persistent Volumes will not be deleted. Administrator has to delete them manually and make sure that directories created by these volumes on cluster nodes are in the expected state. Example Persistent Volumes deletion command:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1241,13 +1241,6 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_go_openapi_spec",
-    importpath = "github.com/go-openapi/spec",
-    sum = "h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=",
-    version = "v0.19.4",
-)
-
-go_repository(
     name = "com_github_go_openapi",
     importpath = "github.com/go-openapi/spec",
     sum = "h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=",
@@ -3142,13 +3135,6 @@ go_repository(
     importpath = "gopkg.in/warnings.v0",
     sum = "h1:XM28wIgFzaBmeZ5dNHIpWLQpt/9DGKxk+rCg/22nnYE=",
     version = "v0.1.1",
-)
-
-go_repository(
-    name = "in_gopkg_yaml_v2",
-    importpath = "gopkg.in/yaml.v2",
-    sum = "h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=",
-    version = "v2.2.8",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,13 +27,32 @@ http_file(
     urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl"],
 )
 
+# overriding org_golang_x_tools from go_rules_dependencies in io_bazel_rules_go
+http_archive(
+    name = "org_golang_x_tools",
+    patch_args = ["-p1"],
+    patches = [
+        "@io_bazel_rules_go//third_party:org_golang_x_tools-deletegopls.patch",
+        "@io_bazel_rules_go//third_party:org_golang_x_tools-gazelle.patch",
+        "@io_bazel_rules_go//third_party:org_golang_x_tools-extras.patch",
+        # Extra go_tool_library targets for gofmt and goimport
+        "//:third_party/org_golang_x_tools.patch",
+    ],
+    sha256 = "cfd9f941c397e6809117a9893bfe53683d963f58fcd3b9d44a2d784eaaacbade",
+    strip_prefix = "tools-57f3fb51f5075e8af9f6ae8bd25e374f4e6b92ed",
+    # master, as of 2020-02-21
+    urls = [
+        "https://mirror.bazel.build/github.com/golang/tools/archive/57f3fb51f5075e8af9f6ae8bd25e374f4e6b92ed.zip",
+        "https://github.com/golang/tools/archive/57f3fb51f5075e8af9f6ae8bd25e374f4e6b92ed.zip",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
 go_register_toolchains(nogo = "@//:nogo")
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
@@ -3527,6 +3546,8 @@ go_repository(
 go_repository(
     name = "org_golang_x_mod",
     importpath = "golang.org/x/mod",
+    patch_args = ["-p1"],
+    patches = ["//:third_party/org_golang_x_mod.patch"],
     sum = "h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=",
     version = "v0.2.0",
 )
@@ -3567,15 +3588,10 @@ go_repository(
 )
 
 go_repository(
-    name = "org_golang_x_tools",
-    importpath = "golang.org/x/tools",
-    sum = "h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=",
-    version = "v0.0.0-20200327195553-82bb89366a1e",
-)
-
-go_repository(
     name = "org_golang_x_xerrors",
     importpath = "golang.org/x/xerrors",
+    patch_args = ["-p1"],
+    patches = ["//:third_party/org_golang_x_xerrors.patch"],
     sum = "h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=",
     version = "v0.0.0-20191204190536-9bdfabe68543",
 )

--- a/contrail-provisioner/main.go
+++ b/contrail-provisioner/main.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	contrail "github.com/Juniper/contrail-go-api"
+
 	contrailTypes "github.com/Juniper/contrail-operator/contrail-provisioner/contrail-go-types"
 	"github.com/Juniper/contrail-operator/contrail-provisioner/types"
 	"github.com/Juniper/contrail-operator/contrail-provisioner/vrouternodes"

--- a/contrail-provisioner/types/base.go
+++ b/contrail-provisioner/types/base.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	contrail "github.com/Juniper/contrail-go-api"
+
 	contrailTypes "github.com/Juniper/contrail-operator/contrail-provisioner/contrail-go-types"
 )
 

--- a/contrail-provisioner/types/vrouter.go
+++ b/contrail-provisioner/types/vrouter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/contrail-go-api"
+
 	contrailTypes "github.com/Juniper/contrail-operator/contrail-provisioner/contrail-go-types"
 )
 

--- a/contrail-provisioner/vrouternodes/vrouter_nodes_test.go
+++ b/contrail-provisioner/vrouternodes/vrouter_nodes_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	contrail "github.com/Juniper/contrail-go-api"
+
 	contrailTypes "github.com/Juniper/contrail-operator/contrail-provisioner/contrail-go-types"
 	"github.com/Juniper/contrail-operator/contrail-provisioner/fake"
 	"github.com/Juniper/contrail-operator/contrail-provisioner/types"

--- a/nogo.json
+++ b/nogo.json
@@ -20,6 +20,12 @@
             "go_default_test": ""
         }
     },
+    "goimports": {
+        "exclude_files": {
+            "external/": "external tools don't pass lint",
+            "go_default_test": ""
+        }
+    },
     "shadow": {
         "only_files": {
             "pkg/label": "",

--- a/pkg/analysis/goimports/BUILD.bazel
+++ b/pkg/analysis/goimports/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["goimports.go"],
+    importpath = "github.com/Juniper/contrail-operator/pkg/analysis/goimports",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golangci_gofmt//goimports:go_default_library",
+        "@org_golang_x_tools//go/analysis:go_default_library",
+        "@org_golang_x_tools//imports:go_default_library",
+    ],
+)
+
+go_tool_library(
+    name = "go_tool_library",
+    srcs = ["goimports.go"],
+    importpath = "github.com/Juniper/contrail-operator/pkg/analysis/goimports",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golangci_gofmt//goimports:go_tool_library",
+        "@org_golang_x_tools//go/analysis:go_tool_library",
+        "@org_golang_x_tools//imports:go_tool_library",
+    ],
+)

--- a/pkg/analysis/goimports/goimports.go
+++ b/pkg/analysis/goimports/goimports.go
@@ -1,0 +1,42 @@
+package goimports
+
+import (
+	"fmt"
+	"go/token"
+
+	goimportsAPI "github.com/golangci/gofmt/goimports"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/imports"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "goimports",
+	Doc:  "Goimports checks whether imports are correctly listed",
+	Run:  run,
+}
+
+func init() {
+	imports.LocalPrefix = "github.com/Juniper/contrail-operator"
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	var fileNames []string
+	for _, f := range pass.Files {
+		pos := pass.Fset.PositionFor(f.Pos(), false)
+		fileNames = append(fileNames, pos.Filename)
+	}
+	for _, f := range fileNames {
+		diff, err := goimportsAPI.Run(f)
+		if err != nil {
+			return nil, err
+		}
+		if diff == nil {
+			continue
+		}
+
+		//TODO improve error reporting
+		text := fmt.Sprintf("file %v is not formated well please run: goimports -local github.com/Juniper/contrail-operator ", f)
+		pass.Report(analysis.Diagnostic{Pos: token.Pos(1), Message: text})
+	}
+	return nil, nil
+}

--- a/pkg/apis/contrail/v1alpha1/manager_types_test.go
+++ b/pkg/apis/contrail/v1alpha1/manager_types_test.go
@@ -3,7 +3,6 @@ package v1alpha1_test
 import (
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,6 +10,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 )
 
 func TestManagerTypeTwo(t *testing.T) {

--- a/pkg/controller/cassandra/cassandra_controller_test.go
+++ b/pkg/controller/cassandra/cassandra_controller_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
-	"github.com/Juniper/contrail-operator/pkg/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
@@ -20,6 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
+	"github.com/Juniper/contrail-operator/pkg/k8s"
 )
 
 func TestCassandraResourceHandler(t *testing.T) {

--- a/pkg/controller/command/command_test.go
+++ b/pkg/controller/command/command_test.go
@@ -3,8 +3,6 @@ package command
 import (
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	"github.com/Juniper/contrail-operator/pkg/k8s"
 	"github.com/stretchr/testify/assert"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -19,6 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	"github.com/Juniper/contrail-operator/pkg/k8s"
 )
 
 // Test function for newReconciler

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 	"github.com/Juniper/contrail-operator/pkg/certificates"
 
-	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	"github.com/Juniper/contrail-operator/pkg/certificates"
-
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -15,16 +15,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	"github.com/Juniper/contrail-operator/pkg/certificates"
 	"github.com/Juniper/contrail-operator/pkg/controller/utils"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("controller_config")

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
-	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
@@ -18,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
+	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 )
 
 func TestConfigResourceHandler(t *testing.T) {

--- a/pkg/controller/enqueue/enqueue_request_for_object_by_owner_test.go
+++ b/pkg/controller/enqueue/enqueue_request_for_object_by_owner_test.go
@@ -1,13 +1,14 @@
 package enqueue
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"testing"
 )
 
 func TestByOwner(t *testing.T) {

--- a/pkg/controller/enqueue/enqueue_request_for_object_group_kind_test.go
+++ b/pkg/controller/enqueue/enqueue_request_for_object_group_kind_test.go
@@ -1,13 +1,14 @@
 package enqueue
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"testing"
 )
 
 func TestObjectGroupKind(t *testing.T) {

--- a/pkg/controller/provisionmanager/provisionmanager_controller_test.go
+++ b/pkg/controller/provisionmanager/provisionmanager_controller_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
-	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
@@ -18,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
+	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 )
 
 type TestCase struct {

--- a/pkg/controller/rabbitmq/rabbitmq_controller_test.go
+++ b/pkg/controller/rabbitmq/rabbitmq_controller_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
-	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
@@ -18,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	mocking "github.com/Juniper/contrail-operator/pkg/controller/mock"
+	"github.com/Juniper/contrail-operator/pkg/controller/utils"
 )
 
 func TestRabbitmqResourceHandler(t *testing.T) {

--- a/pkg/controller/swiftstorage/swift_service_config.go
+++ b/pkg/controller/swiftstorage/swift_service_config.go
@@ -2,10 +2,12 @@ package swiftstorage
 
 import (
 	"bytes"
+	"text/template"
+
+	core "k8s.io/api/core/v1"
+
 	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 	"github.com/Juniper/contrail-operator/pkg/k8s"
-	core "k8s.io/api/core/v1"
-	"text/template"
 )
 
 type swiftServiceConfig struct {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -1,16 +1,18 @@
 package utils_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	tm "github.com/Juniper/contrail-operator/pkg/controller/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	tm "github.com/Juniper/contrail-operator/pkg/controller/utils"
 )
 
 func TestUtils(t *testing.T) {

--- a/pkg/localvolume/volume_test.go
+++ b/pkg/localvolume/volume_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Juniper/contrail-operator/pkg/localvolume"
 	"github.com/stretchr/testify/assert"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Juniper/contrail-operator/pkg/localvolume"
 )
 
 func TestNew(t *testing.T) {

--- a/statusmonitor/config_status_monitor_test.go
+++ b/statusmonitor/config_status_monitor_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
-	contrailOperatorTypes "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+
+	"github.com/stretchr/testify/assert"
+
+	contrailOperatorTypes "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 
 	"net/http"
 	"testing"

--- a/statusmonitor/control_status_monitor_test.go
+++ b/statusmonitor/control_status_monitor_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseControlIntrospectResp(t *testing.T) {

--- a/statusmonitor/main.go
+++ b/statusmonitor/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -23,8 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contrailOperatorTypes "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 )

--- a/statusmonitor/main.go
+++ b/statusmonitor/main.go
@@ -24,8 +24,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 
-	contrailOperatorTypes "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	contrailOperatorTypes "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 )
 
 //NodeType definition

--- a/statusmonitor/main_test.go
+++ b/statusmonitor/main_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func TestGetPods(t *testing.T) {

--- a/test/e2e/ha/BUILD.bazel
+++ b/test/e2e/ha/BUILD.bazel
@@ -35,7 +35,14 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["settings.go"],
+    srcs = [
+        "settings.go",
+        "volumes.go",
+    ],
     importpath = "github.com/Juniper/contrail-operator/test/e2e/ha",
     visibility = ["//visibility:public"],
+    deps = [
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+    ],
 )

--- a/test/e2e/ha/core_contrail_services_test.go
+++ b/test/e2e/ha/core_contrail_services_test.go
@@ -397,7 +397,7 @@ func assertConfigIsHealthy(t *testing.T, proxy *kubeproxy.HTTPProxy, p *core.Pod
 		}
 		res, err = configProxy.Do(req)
 		if err == nil {
-			if res.StatusCode > 400 {
+			if res.StatusCode >= 400 {
 				t.Logf("received status %v", res.StatusCode)
 				return false, nil
 			}

--- a/test/env/client/postgres.go
+++ b/test/env/client/postgres.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-pg/pg/v10/orm"
 
 	"github.com/go-pg/pg/v10"

--- a/test/env/client/postgres.go
+++ b/test/env/client/postgres.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-pg/pg/v10/orm"
-
 	"github.com/go-pg/pg/v10"
+	"github.com/go-pg/pg/v10/orm"
 )
 
 type Postgres struct {

--- a/test/wait/contrail.go
+++ b/test/wait/contrail.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/pkg/test"
+
 	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
 	"github.com/Juniper/contrail-operator/test/logger"
-	"github.com/operator-framework/operator-sdk/pkg/test"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/wait/contrail.go
+++ b/test/wait/contrail.go
@@ -6,15 +6,14 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
-
-	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
-	"github.com/Juniper/contrail-operator/test/logger"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	contrail "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1"
+	"github.com/Juniper/contrail-operator/test/logger"
 )
 
 // Contrail is used to wait until certain contrail resources reach some condition

--- a/third_party/com_github_golangci_gofmt.patch
+++ b/third_party/com_github_golangci_gofmt.patch
@@ -28,3 +28,27 @@ diff -ruN com_github_golangci_gofmt/gofmt/BUILD.bazel com_github_golangci_gofmt_
  go_test(
      name = "go_default_test",
      srcs = [
+
+--- b/goimports/BUILD.bazel	2020-09-04 12:48:16.000000000 +0200
++++ c/goimports/BUILD.bazel	2020-09-04 12:49:19.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -10,3 +10,14 @@
+     visibility = ["//visibility:public"],
+     deps = ["@org_golang_x_tools//imports:go_default_library"],
+ )
++
++go_tool_library(
++    name = "go_tool_library",
++    srcs = [
++        "goimports.go",
++        "golangci.go",
++    ],
++    importpath = "github.com/golangci/gofmt/goimports",
++    visibility = ["//visibility:public"],
++    deps = ["@org_golang_x_tools//imports:go_tool_library"],
++)

--- a/third_party/org_golang_x_mod.patch
+++ b/third_party/org_golang_x_mod.patch
@@ -1,0 +1,50 @@
+diff -ruN org_golang_x_mod/module/BUILD.bazel org_golang_x_mod_/module/BUILD.bazel
+--- org_golang_x_mod/module/BUILD.bazel	2020-09-04 16:22:08.000000000 +0200
++++ org_golang_x_mod_/module/BUILD.bazel	2020-09-04 16:24:25.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -11,6 +11,17 @@
+     ],
+ )
+ 
++go_tool_library(
++    name = "go_tool_library",
++    srcs = ["module.go"],
++    importpath = "golang.org/x/mod/module",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//semver:go_tool_library",
++        "@org_golang_x_xerrors//:go_tool_library",
++    ],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = ["module_test.go"],
+diff -ruN org_golang_x_mod/semver/BUILD.bazel org_golang_x_mod_/semver/BUILD.bazel
+--- org_golang_x_mod/semver/BUILD.bazel	2020-09-04 16:22:09.000000000 +0200
++++ org_golang_x_mod_/semver/BUILD.bazel	2020-09-04 16:23:38.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -7,6 +7,13 @@
+     visibility = ["//visibility:public"],
+ )
+ 
++go_tool_library(
++    name = "go_tool_library",
++    srcs = ["semver.go"],
++    importpath = "golang.org/x/mod/semver",
++    visibility = ["//visibility:public"],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = ["semver_test.go"],

--- a/third_party/org_golang_x_tools.patch
+++ b/third_party/org_golang_x_tools.patch
@@ -1,0 +1,109 @@
+diff -ruN org_golang_x_tools/imports/BUILD.bazel org_golang_x_tools_/imports/BUILD.bazel
+--- org_golang_x_tools/imports/BUILD.bazel	2020-09-04 16:13:11.000000000 +0200
++++ org_golang_x_tools_/imports/BUILD.bazel	2020-09-04 16:17:20.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -7,3 +7,11 @@
+     visibility = ["//visibility:public"],
+     deps = ["//internal/imports:go_default_library"],
+ )
++
++go_tool_library(
++    name = "go_tool_library",
++    srcs = ["forward.go"],
++    importpath = "golang.org/x/tools/imports",
++    visibility = ["//visibility:public"],
++    deps = ["//internal/imports:go_tool_library"],
++)
+diff -ruN org_golang_x_tools/internal/fastwalk/BUILD.bazel org_golang_x_tools_/internal/fastwalk/BUILD.bazel
+--- org_golang_x_tools/internal/fastwalk/BUILD.bazel	2020-09-04 16:13:11.000000000 +0200
++++ org_golang_x_tools_/internal/fastwalk/BUILD.bazel	2020-09-04 16:20:02.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -15,6 +15,21 @@
+     visibility = ["//:__subpackages__"],
+ )
+ 
++go_tool_library(
++    name = "go_tool_library",
++    srcs = [
++        "fastwalk.go",
++        "fastwalk_dirent_fileno.go",
++        "fastwalk_dirent_ino.go",
++        "fastwalk_dirent_namlen_bsd.go",
++        "fastwalk_dirent_namlen_linux.go",
++        "fastwalk_portable.go",
++        "fastwalk_unix.go",
++    ],
++    importpath = "golang.org/x/tools/internal/fastwalk",
++    visibility = ["//:__subpackages__"],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = ["fastwalk_test.go"],
+diff -ruN org_golang_x_tools/internal/gopathwalk/BUILD.bazel org_golang_x_tools_/internal/gopathwalk/BUILD.bazel
+--- org_golang_x_tools/internal/gopathwalk/BUILD.bazel	2020-09-04 16:13:11.000000000 +0200
++++ org_golang_x_tools_/internal/gopathwalk/BUILD.bazel	2020-09-04 16:34:52.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -8,6 +8,14 @@
+     deps = ["//internal/fastwalk:go_default_library"],
+ )
+ 
++go_tool_library(
++    name = "go_tool_library",
++    srcs = ["walk.go"],
++    importpath = "golang.org/x/tools/internal/gopathwalk",
++    visibility = ["//:__subpackages__"],
++    deps = ["//internal/fastwalk:go_tool_library"],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = ["walk_test.go"],
+diff -ruN org_golang_x_tools/internal/imports/BUILD.bazel org_golang_x_tools_/internal/imports/BUILD.bazel
+--- org_golang_x_tools/internal/imports/BUILD.bazel	2020-09-04 16:13:11.000000000 +0200
++++ org_golang_x_tools_/internal/imports/BUILD.bazel	2020-09-04 16:18:45.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -43,3 +43,23 @@
+         "@org_golang_x_mod//module:go_default_library",
+     ],
+ )
++
++go_tool_library(
++    name = "go_tool_library",
++    srcs = [
++        "fix.go",
++        "imports.go",
++        "mod.go",
++        "mod_cache.go",
++        "sortimports.go",
++        "zstdlib.go",
++    ],
++    importpath = "golang.org/x/tools/internal/imports",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//go/ast/astutil:go_tool_library",
++        "//internal/gopathwalk:go_tool_library",
++        "@org_golang_x_mod//module:go_tool_library",
++        "@org_golang_x_mod//semver:go_tool_library",
++    ],
++)

--- a/third_party/org_golang_x_xerrors.patch
+++ b/third_party/org_golang_x_xerrors.patch
@@ -1,0 +1,52 @@
+diff -ruN org_golang_x_xerrors/BUILD.bazel org_golang_x_xerrors_/BUILD.bazel
+--- org_golang_x_xerrors/BUILD.bazel	2020-09-04 16:27:57.000000000 +0200
++++ org_golang_x_xerrors_/BUILD.bazel	2020-09-04 16:29:09.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -16,6 +16,22 @@
+     deps = ["//internal:go_default_library"],
+ )
+ 
++go_tool_library(
++    name = "go_tool_library",
++    srcs = [
++        "adaptor.go",
++        "doc.go",
++        "errors.go",
++        "fmt.go",
++        "format.go",
++        "frame.go",
++        "wrap.go",
++    ],
++    importpath = "golang.org/x/xerrors",
++    visibility = ["//visibility:public"],
++    deps = ["//internal:go_tool_library"],
++)
++
+ go_test(
+     name = "go_default_test",
+     srcs = [
+diff -ruN org_golang_x_xerrors/internal/BUILD.bazel org_golang_x_xerrors_/internal/BUILD.bazel
+--- org_golang_x_xerrors/internal/BUILD.bazel	2020-09-04 16:27:57.000000000 +0200
++++ org_golang_x_xerrors_/internal/BUILD.bazel	2020-09-04 16:29:23.000000000 +0200
+@@ -1,4 +1,4 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_tool_library")
+ 
+ go_library(
+     name = "go_default_library",
+@@ -6,3 +6,10 @@
+     importpath = "golang.org/x/xerrors/internal",
+     visibility = ["//:__subpackages__"],
+ )
++
++go_tool_library(
++    name = "go_tool_library",
++    srcs = ["internal.go"],
++    importpath = "golang.org/x/xerrors/internal",
++    visibility = ["//:__subpackages__"],
++)


### PR DESCRIPTION
This PR fixes imports order and enables automatic check of it during the build.