### PR TITLE
Keystone object-storage service name parameterized

### DIFF
--- a/deploy/crds/contrail.juniper.net_managers_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_managers_crd.yaml
@@ -1887,6 +1887,10 @@ spec:
                                   type: string
                                 swiftConfSecretName:
                                   type: string
+                                swiftServiceName:
+                                  description: Service name registered in Keystone,
+                                    default "swift"
+                                  type: string
                               type: object
                             swiftStorageConfiguration:
                               description: SwiftStorageConfiguration is the Spec for

--- a/deploy/crds/contrail.juniper.net_swiftproxies_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_swiftproxies_crd.yaml
@@ -146,6 +146,9 @@ spec:
                   type: string
                 swiftConfSecretName:
                   type: string
+                swiftServiceName:
+                  description: Service name registered in Keystone, default "swift"
+                  type: string
               type: object
           required:
           - serviceConfiguration

--- a/deploy/crds/contrail.juniper.net_swifts_crd.yaml
+++ b/deploy/crds/contrail.juniper.net_swifts_crd.yaml
@@ -158,6 +158,9 @@ spec:
                       type: string
                     swiftConfSecretName:
                       type: string
+                    swiftServiceName:
+                      description: Service name registered in Keystone, default "swift"
+                      type: string
                   type: object
                 swiftStorageConfiguration:
                   description: SwiftStorageConfiguration is the Spec for the keystone

--- a/pkg/apis/contrail/v1alpha1/defaults.go
+++ b/pkg/apis/contrail/v1alpha1/defaults.go
@@ -234,6 +234,7 @@ const (
 	SandeshCertfile                             string = "/etc/contrail/ssl/certs/server.pem"
 	SandeshKeyfile                              string = "/etc/contrail/ssl/private/server-privkey.pem"
 	SandeshCaCertfile                           string = "/etc/contrail/ssl/certs/ca-cert.pem"
+	SwiftServiceName                            string = "swift"
 	MetadataSslEnable                           string = "false"
 	MetadataSslCertfile                         string = ""
 	MetadataSslKeyfile                          string = ""

--- a/pkg/apis/contrail/v1alpha1/defaults.go
+++ b/pkg/apis/contrail/v1alpha1/defaults.go
@@ -151,12 +151,14 @@ const (
 	KeystoneAuthAdminTenant                     string = "admin"
 	KeystoneAuthAdminUser                       string = "admin"
 	KeystoneAuthAdminPassword                   string = "contrail123"
+	KeystoneAuthProjectDomainID                 string = "default"
+	KeystoneAuthUserDomainID                    string = "default"
 	KeystoneAuthProjectDomainName               string = "Default"
 	KeystoneAuthUserDomainName                  string = "Default"
 	KeystoneAuthRegionName                      string = "RegionOne"
 	KeystoneAuthUrlVersion                      string = "/v3"
 	KeystoneAuthHost                            string = "127.0.0.1"
-	KeystoneAuthProto                           string = "http"
+	KeystoneAuthProto                           string = "https"
 	KeystoneAuthAdminPort                       int    = 35357
 	KeystoneAuthPublicPort                      int    = 5000
 	KeystoneAuthUrlTokens                       string = "/v3/auth/tokens"

--- a/pkg/apis/contrail/v1alpha1/keystone_types.go
+++ b/pkg/apis/contrail/v1alpha1/keystone_types.go
@@ -69,6 +69,33 @@ type KeystoneList struct {
 	Items           []Keystone `json:"items"`
 }
 
+// SetDefaultValues sets default values for keystone resource parameters
+func (k *Keystone) SetDefaultValues() {
+	// After migration to CRD apiextensions.k8s.io/v1 replace those conditions
+	// with +kubebuilder:default markers on keystone struct fileds
+	if k.Spec.ServiceConfiguration.ListenPort == 0 {
+		k.Spec.ServiceConfiguration.ListenPort = KeystoneAuthPublicPort
+	}
+	if k.Spec.ServiceConfiguration.Region == "" {
+		k.Spec.ServiceConfiguration.Region = KeystoneAuthRegionName
+	}
+	if k.Spec.ServiceConfiguration.AuthProtocol == "" {
+		k.Spec.ServiceConfiguration.AuthProtocol = KeystoneAuthProto
+	}
+	if k.Spec.ServiceConfiguration.UserDomainName == "" {
+		k.Spec.ServiceConfiguration.UserDomainName = KeystoneAuthUserDomainName
+	}
+	if k.Spec.ServiceConfiguration.UserDomainID == "" {
+		k.Spec.ServiceConfiguration.UserDomainID = KeystoneAuthUserDomainID
+	}
+	if k.Spec.ServiceConfiguration.ProjectDomainName == "" {
+		k.Spec.ServiceConfiguration.ProjectDomainName = KeystoneAuthProjectDomainName
+	}
+	if k.Spec.ServiceConfiguration.ProjectDomainID == "" {
+		k.Spec.ServiceConfiguration.ProjectDomainID = KeystoneAuthProjectDomainID
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&Keystone{}, &KeystoneList{})
 }

--- a/pkg/apis/contrail/v1alpha1/swift_types.go
+++ b/pkg/apis/contrail/v1alpha1/swift_types.go
@@ -51,6 +51,13 @@ type SwiftList struct {
 	Items           []Swift `json:"items"`
 }
 
+// SetDefaultValues sets default values for swift resource parameters
+func (s *Swift) SetDefaultValues() {
+	if s.Spec.ServiceConfiguration.SwiftProxyConfiguration.SwiftServiceName == "" {
+		s.Spec.ServiceConfiguration.SwiftProxyConfiguration.SwiftServiceName = SwiftServiceName
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&Swift{}, &SwiftList{})
 }

--- a/pkg/apis/contrail/v1alpha1/swiftproxy_types.go
+++ b/pkg/apis/contrail/v1alpha1/swiftproxy_types.go
@@ -22,6 +22,8 @@ type SwiftProxyConfiguration struct {
 	SwiftConfSecretName   string       `json:"swiftConfSecretName,omitempty"`
 	RingConfigMapName     string       `json:"ringConfigMapName,omitempty"`
 	Containers            []*Container `json:"containers,omitempty"`
+	// Service name registered in Keystone, default "swift"
+	SwiftServiceName string `json:"swiftServiceName,omitempty"`
 }
 
 // SwiftProxyStatus defines the observed state of SwiftProxy

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -707,29 +707,7 @@ func (r *ReconcileManager) processKeystone(manager *v1alpha1.Manager, replicas *
 	manager.Spec.Services.Keystone.Spec.ServiceConfiguration.KeystoneSecretName = manager.Spec.KeystoneSecretName
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, keystone, func() error {
 		keystone.Spec = manager.Spec.Services.Keystone.Spec
-		// After migration to CRD apiextensions.k8s.io/v1 replace those conditions
-		// with +kubebuilder:default markers on keystone struct fileds
-		if keystone.Spec.ServiceConfiguration.ListenPort == 0 {
-			keystone.Spec.ServiceConfiguration.ListenPort = 5555
-		}
-		if keystone.Spec.ServiceConfiguration.Region == "" {
-			keystone.Spec.ServiceConfiguration.Region = "RegionOne"
-		}
-		if keystone.Spec.ServiceConfiguration.AuthProtocol == "" {
-			keystone.Spec.ServiceConfiguration.AuthProtocol = "https"
-		}
-		if keystone.Spec.ServiceConfiguration.UserDomainName == "" {
-			keystone.Spec.ServiceConfiguration.UserDomainName = "Default"
-		}
-		if keystone.Spec.ServiceConfiguration.UserDomainID == "" {
-			keystone.Spec.ServiceConfiguration.UserDomainID = "default"
-		}
-		if keystone.Spec.ServiceConfiguration.ProjectDomainName == "" {
-			keystone.Spec.ServiceConfiguration.ProjectDomainName = "Default"
-		}
-		if keystone.Spec.ServiceConfiguration.ProjectDomainID == "" {
-			keystone.Spec.ServiceConfiguration.ProjectDomainID = "default"
-		}
+		keystone.SetDefaultValues()
 		keystone.Spec.CommonConfiguration = utils.MergeCommonConfiguration(manager.Spec.CommonConfiguration, keystone.Spec.CommonConfiguration)
 		if keystone.Spec.CommonConfiguration.Replicas == nil {
 			keystone.Spec.CommonConfiguration.Replicas = replicas

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -774,6 +774,7 @@ func (r *ReconcileManager) processSwift(manager *v1alpha1.Manager, replicas *int
 	swift.ObjectMeta.Namespace = manager.Namespace
 	_, err := controllerutil.CreateOrUpdate(context.Background(), r.client, swift, func() error {
 		swift.Spec = manager.Spec.Services.Swift.Spec
+		swift.SetDefaultValues()
 		swift.Spec.CommonConfiguration = utils.MergeCommonConfiguration(manager.Spec.CommonConfiguration, swift.Spec.CommonConfiguration)
 		if swift.Spec.CommonConfiguration.Replicas == nil {
 			swift.Spec.CommonConfiguration.Replicas = replicas

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1257,7 +1257,7 @@ func TestManagerController(t *testing.T) {
 				},
 				ServiceConfiguration: contrail.KeystoneConfiguration{
 					PostgresInstance:   "psql",
-					ListenPort:         5555,
+					ListenPort:         5000,
 					AuthProtocol:       "https",
 					Region:             "RegionOne",
 					UserDomainName:     "Default",

--- a/pkg/controller/swiftproxy/swiftproxy_config_maps.go
+++ b/pkg/controller/swiftproxy/swiftproxy_config_maps.go
@@ -70,6 +70,7 @@ func (c *configMaps) ensureServiceExists(internalIP string, publicIP string) err
 		KeystoneRegion:          c.keystone.region,
 		SwiftPassword:           string(c.credentialsSecret.Data["password"]),
 		SwiftUser:               string(c.credentialsSecret.Data["user"]),
+		SwiftServiceName:        c.swiftProxySpec.ServiceConfiguration.SwiftServiceName,
 		SwiftPublicEndpoint:     fmt.Sprintf("%v:%v", publicIP, c.swiftProxySpec.ServiceConfiguration.ListenPort),
 		SwiftInternalEndpoint:   fmt.Sprintf("%v:%v", internalIP, c.swiftProxySpec.ServiceConfiguration.ListenPort),
 		CAFilePath:              certificates.SignerCAFilepath,

--- a/pkg/controller/swiftproxy/swiftproxy_controller_test.go
+++ b/pkg/controller/swiftproxy/swiftproxy_controller_test.go
@@ -308,6 +308,7 @@ func newSwiftProxy(status contrail.SwiftProxyStatus) *contrail.SwiftProxy {
 				SwiftConfSecretName:   "test-secret",
 				KeystoneSecretName:    "keystone-adminpass-secret",
 				RingConfigMapName:     "test-ring",
+				SwiftServiceName:      "swift",
 			},
 		},
 		Status: status,
@@ -787,7 +788,7 @@ const registerPlaybook = `
   tasks:
     - name: create swift service
       os_keystone_service:
-        name: "swift"
+        name: "{{ service_name }}"
         service_type: "object-store"
         description: "object store service"
         interface: "admin"
@@ -796,7 +797,7 @@ const registerPlaybook = `
 
     - name: create swift endpoints service
       os_keystone_endpoint:
-        service: "swift"
+        service: "{{ service_name }}"
         url: "{{ item.url }}"
         region: "{{ region_name }}"
         endpoint_interface: "{{ item.interface }}"
@@ -834,7 +835,7 @@ const registerPlaybook = `
         - ResellerAdmin
     - name: grant user role 
       os_user_role:
-        user: "swift"
+        user: "{{ swift_user }}"
         role: "admin"
         project: "service"
         domain: "{{ openstack_auth['user_domain_id'] }}"
@@ -857,6 +858,7 @@ swift_internal_endpoint: "10.10.10.10:5070"
 swift_public_endpoint: "10.255.254.4:5070"
 swift_password: "password2"
 swift_user: "otherUser"
+service_name: "swift"
 
 ca_cert_filepath: "/etc/ssl/certs/kubernetes/ca-bundle.crt"
 `

--- a/pkg/controller/swiftproxy/swiftproxy_register.go
+++ b/pkg/controller/swiftproxy/swiftproxy_register.go
@@ -106,11 +106,11 @@ func (r *ReconcileSwiftProxy) isSwiftRegistered(sp *contrail.SwiftProxy, k *cont
 		return false, fmt.Errorf("failed to get keystone token: %v", err)
 	}
 
-	url := token.EndpointURL("swift", "internal")
+	url := token.EndpointURL(sp.Spec.ServiceConfiguration.SwiftServiceName, "internal")
 	if !strings.Contains(url, sp.Status.ClusterIP) {
 		return false, nil
 	}
-	url = token.EndpointURL("swift", "public")
+	url = token.EndpointURL(sp.Spec.ServiceConfiguration.SwiftServiceName, "public")
 	if sp.Status.LoadBalancerIP != "" && !strings.Contains(url, sp.Status.LoadBalancerIP) {
 		return false, nil
 	}

--- a/pkg/controller/swiftproxy/swiftproxy_register_playbook.go
+++ b/pkg/controller/swiftproxy/swiftproxy_register_playbook.go
@@ -19,6 +19,7 @@ type registerServiceConfig struct {
 	SwiftPublicEndpoint     string
 	SwiftPassword           string
 	SwiftUser               string
+	SwiftServiceName        string
 	CAFilePath              string
 }
 
@@ -40,7 +41,7 @@ const registerPlaybook = `
   tasks:
     - name: create swift service
       os_keystone_service:
-        name: "swift"
+        name: "{{ service_name }}"
         service_type: "object-store"
         description: "object store service"
         interface: "admin"
@@ -49,7 +50,7 @@ const registerPlaybook = `
 
     - name: create swift endpoints service
       os_keystone_endpoint:
-        service: "swift"
+        service: "{{ service_name }}"
         url: "{{ item.url }}"
         region: "{{ region_name }}"
         endpoint_interface: "{{ item.interface }}"
@@ -87,7 +88,7 @@ const registerPlaybook = `
         - ResellerAdmin
     - name: grant user role 
       os_user_role:
-        user: "swift"
+        user: "{{ swift_user }}"
         role: "admin"
         project: "service"
         domain: "{{ openstack_auth['user_domain_id'] }}"
@@ -110,6 +111,7 @@ swift_internal_endpoint: "{{ .SwiftInternalEndpoint }}"
 swift_public_endpoint: "{{ .SwiftPublicEndpoint }}"
 swift_password: "{{ .SwiftPassword }}"
 swift_user: "{{ .SwiftUser }}"
+service_name: "{{ .SwiftServiceName }}"
 
 ca_cert_filepath: "{{ .CAFilePath }}"
 `))

--- a/test/e2e/aio/openstack_test.go
+++ b/test/e2e/aio/openstack_test.go
@@ -218,6 +218,7 @@ func TestOpenstackServices(t *testing.T) {
 							ListenPort:         5070,
 							KeystoneInstance:   "openstacktest-keystone",
 							KeystoneSecretName: "openstacktest-keystone-adminpass-secret",
+							SwiftServiceName:   "contrail-swift",
 							Containers: []*contrail.Container{
 								{Name: "wait-for-ready-conf", Image: "registry:5000/common-docker-third-party/contrail/busybox:1.31"},
 								{Name: "init", Image: "registry:5000/common-docker-third-party/contrail/centos-binary-kolla-toolbox:train-2005"},
@@ -260,7 +261,7 @@ func TestOpenstackServices(t *testing.T) {
 				keystoneClient, _ = getKeystoneClient(f, namespace, "openstacktest-keystone")
 				tokens, _         = keystoneClient.PostAuthTokens("swift", "swiftPass", "service")
 				swiftProxy        = proxy.NewSecureClientForService("contrail", "openstacktest-swift-proxy-swift-proxy", 5070)
-				swiftURL          = tokens.EndpointURL("swift", "internal")
+				swiftURL          = tokens.EndpointURL("contrail-swift", "internal")
 				swiftClient, err  = swift.NewClient(swiftProxy, tokens.XAuthTokenHeader, swiftURL)
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
When external keystone is in use it can already has a definition of
object-storage service. With SwiftServiceName property it is now
possible to decide about service name created by operator in keystone.
Default value is set to "swift".