### PR TITLE
Removing creation of new Tickers that may cause memory leaking

### DIFF
--- a/statusmonitor/main.go
+++ b/statusmonitor/main.go
@@ -118,7 +118,6 @@ func main() {
 					log.Printf("kubernates client creation failed: %v", err)
 					continue
 				}
-				ticker = time.NewTicker(time.Duration(config.Interval) * time.Second)
 				switch config.NodeType {
 				case "control":
 					err := getControlStatus(client, clientset, restClient, config)


### PR DESCRIPTION
Code in statusmonitor created a new Ticker each tick and never executed the Stop method on them. As mentioned here https://go101.org/article/memory-leaking.html it may cause a memory leak. 

I recreated a simple program that does only this one thing ( code below) and memory consumed by the process, as reported by htop, grows constantly. But interestingly, heap reports by pprof don't show the growing heap usage, so I'm not sure what's going on, maybe I'm using it wrong.

Golang's source code mentions that Tickers are not garbage collected, https://golang.org/src/time/tick.go:
```
// Tick is a convenience wrapper for NewTicker providing access to the ticking
// channel only. While Tick is useful for clients that have no need to shut down
// the Ticker, be aware that without a way to shut it down the underlying
// Ticker cannot be recovered by the garbage collector; it "leaks".
// Unlike NewTicker, Tick will return nil if d <= 0.
func Tick(d Duration) <-chan Time {
	if d <= 0 {
		return nil
	}
	return NewTicker(d).C
}
```

Test code:
```
package main

import (
	"log"
	"net/http"
	"time"

	_ "net/http/pprof"
)

func main() {
	go func() {
		log.Println(http.ListenAndServe("localhost:6542", nil))
	}()

	ticker := time.NewTicker(time.Duration(1) * time.Millisecond)
	done := make(chan bool)
	go func() {
		for {
			select {
			case t := <-ticker.C:
				ticker = time.NewTicker(time.Duration(1) * time.Millisecond)
				_ = t
			}
		}
	}()
	done <- true
	log.Println("Ticker stopped")
}
```