### PR TITLE
Statusmonitor memory leaks

### DIFF
--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -77,7 +77,7 @@ spec:
             - name: queryengine
               image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: pitersk/contrail-statusmonitor:2008.leaks
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -103,7 +103,7 @@ spec:
             - name: named
               image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: pitersk/contrail-statusmonitor:2008.leaks
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -194,7 +194,7 @@ spec:
             - name: kubemanager
               image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: pitersk/contrail-statusmonitor:2008.leaks
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/0000000-contrail-09-manager.yaml
@@ -77,7 +77,7 @@ spec:
             - name: queryengine
               image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
+              image: pitersk/contrail-statusmonitor:2008.leaks
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -103,7 +103,7 @@ spec:
             - name: named
               image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
+              image: pitersk/contrail-statusmonitor:2008.leaks
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -194,7 +194,7 @@ spec:
             - name: kubemanager
               image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-rhel
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
+              image: pitersk/contrail-statusmonitor:2008.leaks
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/statusmonitor/config_status_monitor.go
+++ b/statusmonitor/config_status_monitor.go
@@ -98,6 +98,9 @@ func getConfigStatusFromApiServer(serviceAddress, serviceName string, client *ht
 	url := "https://" + serviceAddress + "/Snh_SandeshUVECacheReq?x=NodeStatus"
 	moduleNameFmt := formatServiceName(serviceName)
 	resp, err := client.Get(url)
+	if resp != nil {
+		defer closeResp(resp)
+	}
 	if err != nil {
 		state := "connection-error"
 		if isBackupImplementedService(serviceName) {
@@ -111,7 +114,6 @@ func getConfigStatusFromApiServer(serviceAddress, serviceName string, client *ht
 		log.Printf("warning: to get status for %s address %s failed: %v", serviceName, serviceAddress, err)
 		return
 	}
-	defer closeResp(resp)
 	if resp != nil {
 		log.Printf("resp not nil %d ", resp.StatusCode)
 		if resp.StatusCode == http.StatusOK {

--- a/statusmonitor/main.go
+++ b/statusmonitor/main.go
@@ -202,7 +202,7 @@ func GetControlStatusFromApiServer(apiServer string, config *Config, client *htt
 			defer closeResp(resp)
 		}
 		process_resp, err_p := client.Get(process_url)
-		if process_resps != nil {
+		if process_resp != nil {
 			defer closeResp(process_resp)
 		}
 		if err != nil {


### PR DESCRIPTION
I found some possible causes of memory leaks. Calls to function that closes http response bodies were deferred after some logic that could return, so the response body would not be closed. 

I moved the defer of the response body closing function to be right after the http request is made.

This particular mistake is described here http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#close_http_resp_body

I also removed some strange if else statements that were not checking anything.

It looks like the increasing memory usage was caused because new http clients for contrail and kubernetes were created in each iteration of the loop. I'm not sure why the unused clients were not freed (maybe there were some open http connections referencing them). 

Anyway, I modified the code to create the clients once and reuse them in the loop.