### PR TITLE
Clear leftovers of local-storage mounts

### DIFF
--- a/test/env/clear_contrail_cluster.sh
+++ b/test/env/clear_contrail_cluster.sh
@@ -9,5 +9,5 @@ kubectl delete pv $(kubectl get pv -o=jsonpath='{.items[?(@.spec.storageClassNam
 
 for p in $(docker ps --filter name=kind-control --filter name=kind-worker -q)
 do
-    docker exec $p rm -rf /mnt/storage
+    docker exec $p sh -c 'rm -rf /mnt/*'
 done


### PR DESCRIPTION
Especially for cleaning postgres files as if new deployment will
be run on the same cluster it will try reuse old files and patroni
may complain about invalid credentials if those were different
in new deployment. It's only solves issue for test environments.