### PR TITLE
Vrouter improvements

### DIFF
--- a/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
+++ b/pkg/apis/contrail/v1alpha1/tests/config_vrouter_test.go
@@ -96,7 +96,6 @@ func TestVrouterDefaultEnvVariablesConfigMap(t *testing.T) {
 	}
 
 	expectedVrouterEnvVariables := map[string]string{
-		"PHYSICAL_INTERFACE": "eth0",
 		"CLOUD_ORCHESTRATOR": "kubernetes",
 		"VROUTER_ENCRYPTION": "false",
 	}
@@ -110,6 +109,7 @@ func TestVrouterCustomEnvVariablesConfigMap(t *testing.T) {
 	cl := *environment.client
 
 	environment.vrouterResource.Spec.ServiceConfiguration.VrouterEncryption = true
+	environment.vrouterResource.Spec.ServiceConfiguration.PhysicalInterface = "eth0"
 
 	if err := environment.vrouterResource.InstanceConfiguration(reconcile.Request{types.NamespacedName{Name: "vrouter1", Namespace: "default"}},
 		&environment.vrouterPodList, cl); err != nil {

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -325,7 +325,6 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
 	var data = make(map[string]string)
 	for idx := range podList.Items {
-		// GENERATE configmaps peor pod (at least the one with ENV vars)
 		hostname := podList.Items[idx].Annotations["hostname"]
 		physicalInterfaceMac := podList.Items[idx].Annotations["physicalInterfaceMac"]
 		prefixLength := podList.Items[idx].Annotations["prefixLength"]

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -134,6 +134,19 @@ func (c *Vrouter) PrepareDaemonSet(ds *appsv1.DaemonSet,
 		instanceType: request.Name}
 	ds.Spec.Template.SetLabels(map[string]string{"contrail_manager": instanceType,
 		instanceType: request.Name})
+	ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      instanceType,
+						Operator: "Exists",
+					}},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			}},
+		},
+	}
 	err := controllerutil.SetControllerReference(c, ds, scheme)
 	if err != nil {
 		return err

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -321,6 +321,7 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	var data = make(map[string]string)
 	var envVariables = make(map[string]string)
 	for idx := range podList.Items {
+		// GENERATE configmaps peor pod (at least the one with ENV vars)
 		hostname := podList.Items[idx].Annotations["hostname"]
 		physicalInterfaceMac := podList.Items[idx].Annotations["physicalInterfaceMac"]
 		prefixLength := podList.Items[idx].Annotations["prefixLength"]
@@ -336,7 +337,6 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		} else {
 			gateway = podList.Items[idx].Annotations["gateway"]
 		}
-		envVariables["PHYSICAL_INTERFACE"] = physicalInterface
 		envVariables["CLOUD_ORCHESTRATOR"] = "kubernetes"
 		envVariables["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
 		var vrouterConfigBuffer bytes.Buffer

--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -25,6 +25,15 @@ func GetDaemonset() *apps.DaemonSet {
 		},
 	}
 
+	var physicalInterfaceEnv = core.EnvVar{
+		Name: "PHYSICAL_INTERFACE",
+		ValueFrom: &core.EnvVarSource{
+			FieldRef: &core.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['<KEY>']"
+			}
+		},
+	}
+
 	var podInitContainers = []core.Container{
 		{
 			Name:  "init",

--- a/pkg/controller/vrouter/daemonset.go
+++ b/pkg/controller/vrouter/daemonset.go
@@ -29,8 +29,8 @@ func GetDaemonset() *apps.DaemonSet {
 		Name: "PHYSICAL_INTERFACE",
 		ValueFrom: &core.EnvVarSource{
 			FieldRef: &core.ObjectFieldSelector{
-				FieldPath: "metadata.annotations['<KEY>']"
-			}
+				FieldPath: "metadata.annotations['physicalInterface']",
+			},
 		},
 	}
 
@@ -112,6 +112,7 @@ func GetDaemonset() *apps.DaemonSet {
 			Name:  "vrouteragent",
 			Image: "docker.io/michaelhenkel/contrail-vrouter-agent:5.2.0-dev1",
 			Env: []core.EnvVar{
+				physicalInterfaceEnv,
 				podIPEnv,
 			},
 			VolumeMounts: []core.VolumeMount{


### PR DESCRIPTION
This PR modifies the spec of vrouter pod in a way that the PHYSICAL_INTERFACE environment variable is set using a reference to annotation instead of taking a value from a ConfigMap. This way, each pod can have a different value of this env var. Previously all pods under the same vrouter custom resource had to use the same value of this env var, so all nodes had to have the same name of the physical interface.

Additionally there is the option to set the physicalInterface via service configuration. It then overrides the value set by the annotation with a value from the config map. I'm not sure about the use-case of it (maybe when nodes have multiple interfaces), but it was there before, so I left it.

I also added a pod anti-affinity so that two vrouter pods will not be scheduled on the same node. This could happen for example if a node would have both the master and worker label and there were to vrouter CRs, one with nodeSelector for master label, and another with nodeSelector for the worker label.