### PR TITLE
Refactor config generation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "nogo")
 
 #gazelle:prefix github.com/Juniper/contrail-operator
 # gazelle:proto disable_global
@@ -39,4 +39,17 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["test-main.go"],
+    importpath = "github.com/Juniper/contrail-operator",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "contrail-operator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
 
 #gazelle:prefix github.com/Juniper/contrail-operator
 # gazelle:proto disable_global
@@ -39,17 +39,4 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
-)
-
-go_library(
-    name = "go_default_library",
-    srcs = ["test-main.go"],
-    importpath = "github.com/Juniper/contrail-operator",
-    visibility = ["//visibility:private"],
-)
-
-go_binary(
-    name = "contrail-operator",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )

--- a/pkg/apis/contrail/v1alpha1/base_types.go
+++ b/pkg/apis/contrail/v1alpha1/base_types.go
@@ -780,10 +780,6 @@ func NewCassandraClusterConfiguration(name string, namespace string, client clie
 func NewControlClusterConfiguration(name string, role string, namespace string, myclient client.Client) (*ControlClusterConfiguration, error) {
 	var controlNodes []string
 	var controlCluster ControlClusterConfiguration
-	var bgpPort string
-	var dnsPort string
-	var xmppPort string
-	var dnsIntrospectPort string
 	var controlConfigInterface interface{}
 	if name != "" {
 		controlInstance := &Control{}
@@ -814,30 +810,13 @@ func NewControlClusterConfiguration(name string, role string, namespace string, 
 		controlConfigInterface = controlList.Items[0].ConfigurationParameters()
 	}
 	controlConfig := controlConfigInterface.(ControlConfiguration)
-	bgpPort = strconv.Itoa(*controlConfig.BGPPort)
-	dnsPort = strconv.Itoa(*controlConfig.DNSPort)
-	xmppPort = strconv.Itoa(*controlConfig.XMPPPort)
-	dnsIntrospectPort = strconv.Itoa(*controlConfig.DNSIntrospectPort)
 	sort.SliceStable(controlNodes, func(i, j int) bool { return controlNodes[i] < controlNodes[j] })
-	serverListXMPPCommaSeparated := strings.Join(controlNodes, ":"+xmppPort+",")
-	serverListXMPPCommaSeparated = serverListXMPPCommaSeparated + ":" + xmppPort
-	serverListXMPPSpaceSeparated := strings.Join(controlNodes, ":"+xmppPort+" ")
-	serverListXMPPSpaceSeparated = serverListXMPPSpaceSeparated + ":" + xmppPort
-	serverListDNSCommaSeparated := strings.Join(controlNodes, ":"+dnsPort+",")
-	serverListDNSCommaSeparated = serverListDNSCommaSeparated + ":" + dnsPort
-	serverListDNSSpaceSeparated := strings.Join(controlNodes, ":"+dnsPort+" ")
-	serverListDNSSpaceSeparated = serverListDNSSpaceSeparated + ":" + dnsPort
-	serverListCommanSeparatedQuoted := strings.Join(controlNodes, "','")
-	serverListCommanSeparatedQuoted = "'" + serverListCommanSeparatedQuoted + "'"
 	controlCluster = ControlClusterConfiguration{
-		BGPPort:                         bgpPort,
-		DNSPort:                         dnsPort,
-		DNSIntrospectPort:               dnsIntrospectPort,
-		ServerListXMPPCommaSeparated:    serverListXMPPCommaSeparated,
-		ServerListXMPPSpaceSeparated:    serverListXMPPSpaceSeparated,
-		ServerListDNSCommaSeparated:     serverListDNSCommaSeparated,
-		ServerListDNSSpaceSeparated:     serverListDNSSpaceSeparated,
-		ServerListCommanSeparatedQuoted: serverListCommanSeparatedQuoted,
+		XMPPPort:            *controlConfig.XMPPPort,
+		BGPPort:             *controlConfig.BGPPort,
+		DNSPort:             *controlConfig.DNSPort,
+		DNSIntrospectPort:   *controlConfig.DNSIntrospectPort,
+		ControlServerIPList: controlNodes,
 	}
 
 	return &controlCluster, nil
@@ -935,11 +914,8 @@ func NewConfigClusterConfiguration(name string, namespace string, myclient clien
 		return &configCluster, err
 	}
 
-	var apiServerPort string
-	var collectorServerPort string
-	var analyticsServerPort string
-	var redisServerPort string
 	var authMode AuthenticationMode
+	var apiServerPort, analyticsPort, collectorPort, redisPort int
 
 	if len(configList.Items) > 0 {
 		for _, ip := range configList.Items[0].Status.Nodes {
@@ -948,37 +924,21 @@ func NewConfigClusterConfiguration(name string, namespace string, myclient clien
 		configConfigInterface := configList.Items[0].ConfigurationParameters()
 		configConfig := configConfigInterface.(ConfigConfiguration)
 		authMode = configConfig.AuthMode
-		apiServerPort = strconv.Itoa(*configConfig.APIPort)
-		analyticsServerPort = strconv.Itoa(*configConfig.AnalyticsPort)
-		collectorServerPort = strconv.Itoa(*configConfig.CollectorPort)
-		redisServerPort = strconv.Itoa(*configConfig.RedisPort)
+		apiServerPort = *configConfig.APIPort
+		analyticsPort = *configConfig.AnalyticsPort
+		collectorPort = *configConfig.CollectorPort
+		redisPort = *configConfig.RedisPort
 	}
 	sort.SliceStable(configNodes, func(i, j int) bool { return configNodes[i] < configNodes[j] })
-	apiServerListQuotedCommaSeparated := strings.Join(configNodes, "','")
-	firstAPIServer := configNodes[0]
-	apiServerListQuotedCommaSeparated = "'" + apiServerListQuotedCommaSeparated + "'"
-	analyticsServerListQuotedCommaSeparated := strings.Join(configNodes, "','")
-	analyticsServerListQuotedCommaSeparated = "'" + analyticsServerListQuotedCommaSeparated + "'"
-	apiServerListCommaSeparated := strings.Join(configNodes, ",")
-	apiServerListSpaceSeparated := strings.Join(configNodes, ":"+apiServerPort+" ")
-	apiServerListSpaceSeparated = apiServerListSpaceSeparated + ":" + apiServerPort
-	analyticsServerListSpaceSeparated := strings.Join(configNodes, ":"+analyticsServerPort+" ")
-	analyticsServerListSpaceSeparated = analyticsServerListSpaceSeparated + ":" + analyticsServerPort
-	collectorServerListSpaceSeparated := strings.Join(configNodes, ":"+collectorServerPort+" ")
-	collectorServerListSpaceSeparated = collectorServerListSpaceSeparated + ":" + collectorServerPort
 	configCluster = ConfigClusterConfiguration{
-		APIServerPort:                           apiServerPort,
-		APIServerListQuotedCommaSeparated:       apiServerListQuotedCommaSeparated,
-		APIServerListCommaSeparated:             apiServerListCommaSeparated,
-		APIServerListSpaceSeparated:             apiServerListSpaceSeparated,
-		AnalyticsServerPort:                     analyticsServerPort,
-		AnalyticsServerListSpaceSeparated:       analyticsServerListSpaceSeparated,
-		AnalyticsServerListQuotedCommaSeparated: analyticsServerListQuotedCommaSeparated,
-		CollectorPort:                           collectorServerPort,
-		CollectorServerListSpaceSeparated:       collectorServerListSpaceSeparated,
-		FirstAPIServer:                          firstAPIServer,
-		RedisPort:                               redisServerPort,
-		AuthMode:                                authMode,
+		APIServerPort:         apiServerPort,
+		APIServerIPList:       configNodes,
+		AnalyticsServerPort:   analyticsPort,
+		AnalyticsServerIPList: configNodes,
+		CollectorPort:         collectorPort,
+		CollectorServerIPList: configNodes,
+		RedisPort:             redisPort,
+		AuthMode:              authMode,
 	}
 	return &configCluster, nil
 }
@@ -997,38 +957,23 @@ type CommandClusterConfiguration struct {
 
 // ConfigClusterConfiguration defines all configuration knobs used to write the config file.
 type ConfigClusterConfiguration struct {
-	APIServerPort                           string
-	APIServerListSpaceSeparated             string
-	APIServerListQuotedCommaSeparated       string
-	APIServerListCommaSeparated             string
-	AnalyticsServerPort                     string
-	AnalyticsServerListSpaceSeparated       string
-	AnalyticsServerListQuotedCommaSeparated string
-	CollectorServerListSpaceSeparated       string
-	CollectorPort                           string
-	FirstAPIServer                          string
-	RedisPort                               string
-	AuthMode                                AuthenticationMode
-}
-
-func (c *ConfigClusterConfiguration) APIServerListSpaceSeparated() string {
-	return c.APIServerListSpaceSeparated
+	APIServerPort         int
+	APIServerIPList       []string
+	AnalyticsServerPort   int
+	AnalyticsServerIPList []string
+	CollectorPort         int
+	CollectorServerIPList []string
+	RedisPort             int
+	AuthMode              AuthenticationMode
 }
 
 // ControlClusterConfiguration defines all configuration knobs used to write the config file.
 type ControlClusterConfiguration struct {
-	BGPPort                         string
-	DNSPort                         string
-	DNSIntrospectPort               string
-	ServerListXMPPCommaSeparated    string
-	ServerListXMPPSpaceSeparated    string
-	ServerListDNSCommaSeparated     string
-	ServerListDNSSpaceSeparated     string
-	ServerListCommanSeparatedQuoted string
-}
-
-func (c *ControlClusterConfiguration) ServerListXMPPSpaceSeparated() string {
-	return c.ServerListXMPPSpaceSeparated
+	XMPPPort            int
+	BGPPort             int
+	DNSPort             int
+	DNSIntrospectPort   int
+	ControlServerIPList []string
 }
 
 // ZookeeperClusterConfiguration defines all configuration knobs used to write the config file.

--- a/pkg/apis/contrail/v1alpha1/base_types.go
+++ b/pkg/apis/contrail/v1alpha1/base_types.go
@@ -1011,6 +1011,10 @@ type ConfigClusterConfiguration struct {
 	AuthMode                                AuthenticationMode
 }
 
+func (c *ConfigClusterConfiguration) APIServerListSpaceSeparated() string {
+	return c.APIServerListSpaceSeparated
+}
+
 // ControlClusterConfiguration defines all configuration knobs used to write the config file.
 type ControlClusterConfiguration struct {
 	BGPPort                         string
@@ -1021,6 +1025,10 @@ type ControlClusterConfiguration struct {
 	ServerListDNSCommaSeparated     string
 	ServerListDNSSpaceSeparated     string
 	ServerListCommanSeparatedQuoted string
+}
+
+func (c *ControlClusterConfiguration) ServerListXMPPSpaceSeparated() string {
+	return c.ServerListXMPPSpaceSeparated
 }
 
 // ZookeeperClusterConfiguration defines all configuration knobs used to write the config file.

--- a/pkg/apis/contrail/v1alpha1/control_types.go
+++ b/pkg/apis/contrail/v1alpha1/control_types.go
@@ -191,6 +191,7 @@ func (c *Control) InstanceConfiguration(request reconcile.Request,
 		}
 		data["monitorconfig."+podList.Items[idx].Status.PodIP+".yaml"] = statusMonitorConfig
 
+		configApiIPListSpaceSeparated := configtemplates.IPListSpaceSeparated(configNodesInformation.APIServerIPList)
 		configApiIPListCommaSeparated := configtemplates.IPListCommaSeparated(configNodesInformation.APIServerIPList)
 		configApiIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
 		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
@@ -215,7 +216,7 @@ func (c *Control) InstanceConfiguration(request reconcile.Request,
 			Hostname:            hostname,
 			BGPPort:             strconv.Itoa(*controlConfig.BGPPort),
 			ASNNumber:           strconv.Itoa(*controlConfig.ASNNumber),
-			APIServerList:       configApiIPListCommaSeparated,
+			APIServerList:       configApiIPListSpaceSeparated,
 			APIServerPort:       strconv.Itoa(configNodesInformation.APIServerPort),
 			CassandraServerList: cassandraNodesInformation.ServerListCQLSpaceSeparated,
 			RabbitmqServerList:  rabbitmqNodesInformation.ServerListSpaceSeparatedSSL,
@@ -250,7 +251,7 @@ func (c *Control) InstanceConfiguration(request reconcile.Request,
 		}{
 			ListenAddress:       podList.Items[idx].Status.PodIP,
 			Hostname:            hostname,
-			APIServerList:       configApiIPListCommaSeparated,
+			APIServerList:       configApiIPListSpaceSeparated,
 			APIServerPort:       strconv.Itoa(configNodesInformation.APIServerPort),
 			CassandraServerList: cassandraNodesInformation.ServerListCQLSpaceSeparated,
 			RabbitmqServerList:  rabbitmqNodesInformation.ServerListSpaceSeparatedSSL,

--- a/pkg/apis/contrail/v1alpha1/control_types.go
+++ b/pkg/apis/contrail/v1alpha1/control_types.go
@@ -191,10 +191,11 @@ func (c *Control) InstanceConfiguration(request reconcile.Request,
 		}
 		data["monitorconfig."+podList.Items[idx].Status.PodIP+".yaml"] = statusMonitorConfig
 
-		configApiIPListSpaceSeparated := configtemplates.IPListSpaceSeparated(configNodesInformation.APIServerIPList)
-		configApiIPListCommaSeparated := configtemplates.IPListCommaSeparated(configNodesInformation.APIServerIPList)
-		configApiIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
-		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		configApiIPListSpaceSeparated := configtemplates.JoinListWithSeparator(configNodesInformation.APIServerIPList, " ")
+		configApiIPListCommaSeparated := configtemplates.JoinListWithSeparator(configNodesInformation.APIServerIPList, ",")
+		configApiIPListCommaSeparatedQuoted := configtemplates.JoinListWithSeparatorAndSingleQuotes(configNodesInformation.APIServerIPList, ",")
+		configCollectorEndpointList := configtemplates.EndpointList(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		configCollectorEndpointListSpaceSeparated := configtemplates.JoinListWithSeparator(configCollectorEndpointList, " ")
 		var controlControlConfigBuffer bytes.Buffer
 		configtemplates.ControlControlConfig.Execute(&controlControlConfigBuffer, struct {
 			ListenAddress       string

--- a/pkg/apis/contrail/v1alpha1/kubemanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/kubemanager_types.go
@@ -193,8 +193,9 @@ func (c *Kubemanager) InstanceConfiguration(request reconcile.Request,
 		}
 		data["monitorconfig."+podList.Items[idx].Status.PodIP+".yaml"] = statusMonitorConfig
 
-		configApiIPListCommaSeparated := configtemplates.IPListCommaSeparated(configNodesInformation.APIServerIPList)
-		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		configApiIPListCommaSeparated := configtemplates.JoinListWithSeparator(configNodesInformation.APIServerIPList, ",")
+		configCollectorEndpointList := configtemplates.EndpointList(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		configCollectorEndpointListSpaceSeparated := configtemplates.JoinListWithSeparator(configCollectorEndpointList, " ")
 		var kubemanagerConfigBuffer bytes.Buffer
 		secret := &corev1.Secret{}
 		if err = client.Get(context.TODO(), types.NamespacedName{Name: "kubemanagersecret", Namespace: request.Namespace}, secret); err != nil {

--- a/pkg/apis/contrail/v1alpha1/kubemanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/kubemanager_types.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"sort"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,14 +185,16 @@ func (c *Kubemanager) InstanceConfiguration(request reconcile.Request,
 	var data = map[string]string{}
 	for idx := range podList.Items {
 		hostname := podList.Items[idx].Annotations["hostname"]
-		configNodesList := strings.Split(configNodesInformation.AnalyticsServerListSpaceSeparated, " ")
-		statusMonitorConfig, err := StatusMonitorConfig(hostname, configNodesList, podList.Items[idx].Status.PodIP,
+		configAnalyticsEndpoints := configtemplates.EndpointList(configNodesInformation.AnalyticsServerIPList, configNodesInformation.AnalyticsServerPort)
+		statusMonitorConfig, err := StatusMonitorConfig(hostname, configAnalyticsEndpoints, podList.Items[idx].Status.PodIP,
 			"kubemanager", request.Name, request.Namespace, podList.Items[idx].Name)
 		if err != nil {
 			return err
 		}
 		data["monitorconfig."+podList.Items[idx].Status.PodIP+".yaml"] = statusMonitorConfig
 
+		configApiIPListCommaSeparated := configtemplates.IPListCommaSeparated(configNodesInformation.APIServerIPList)
+		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
 		var kubemanagerConfigBuffer bytes.Buffer
 		secret := &corev1.Secret{}
 		if err = client.Get(context.TODO(), types.NamespacedName{Name: "kubemanagersecret", Namespace: request.Namespace}, secret); err != nil {
@@ -238,13 +239,13 @@ func (c *Kubemanager) InstanceConfiguration(request reconcile.Request,
 			ServiceSubnet:         kubemanagerConfig.ServiceSubnets,
 			IPFabricForwarding:    strconv.FormatBool(*kubemanagerConfig.IPFabricForwarding),
 			IPFabricSnat:          strconv.FormatBool(*kubemanagerConfig.IPFabricSnat),
-			APIServerList:         configNodesInformation.APIServerListCommaSeparated,
-			APIServerPort:         configNodesInformation.APIServerPort,
+			APIServerList:         configApiIPListCommaSeparated,
+			APIServerPort:         strconv.Itoa(configNodesInformation.APIServerPort),
 			CassandraServerList:   cassandraNodesInformation.Endpoint,
 			ZookeeperServerList:   zookeeperNodesInformation.ServerListCommaSeparated,
 			RabbitmqServerList:    rabbitmqNodesInformation.ServerListCommaSeparatedWithoutPort,
 			RabbitmqServerPort:    rabbitmqNodesInformation.SSLPort,
-			CollectorServerList:   configNodesInformation.CollectorServerListSpaceSeparated,
+			CollectorServerList:   configCollectorEndpointListSpaceSeparated,
 			HostNetworkService:    strconv.FormatBool(*kubemanagerConfig.HostNetworkService),
 			RabbitmqUser:          rabbitmqSecretUser,
 			RabbitmqPassword:      rabbitmqSecretPassword,
@@ -260,7 +261,7 @@ func (c *Kubemanager) InstanceConfiguration(request reconcile.Request,
 			CAFilePath    string
 		}{
 			ListenAddress: podList.Items[idx].Status.PodIP,
-			ListenPort:    configNodesInformation.APIServerPort,
+			ListenPort:    strconv.Itoa(configNodesInformation.APIServerPort),
 			CAFilePath:    certificates.SignerCAFilepath,
 		})
 		data["vnc."+podList.Items[idx].Status.PodIP] = vncApiConfigBuffer.String()

--- a/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -456,7 +455,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 	}
 	for _, pod := range podList.Items {
 		apiServer := &APIServer{
-			APIServerList: strings.Split(configNodesInformation.APIServerListSpaceSeparated, " "),
+			APIServerList: configNodesInformation.APIServerIPList,
 			APIPort:       apiPort,
 			Encryption: Encryption{
 				CA:       certificates.SignerCAFilepath,

--- a/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
@@ -17,6 +17,7 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configtemplates "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1/templates"
 	"github.com/Juniper/contrail-operator/pkg/certificates"
 )
 
@@ -455,7 +456,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 	}
 	for _, pod := range podList.Items {
 		apiServer := &APIServer{
-			APIServerList: configNodesInformation.APIServerIPList,
+			APIServerList: configtemplates.EndpointList(configNodesInformation.APIServerIPList, configNodesInformation.APIServerPort),
 			APIPort:       apiPort,
 			Encryption: Encryption{
 				CA:       certificates.SignerCAFilepath,

--- a/pkg/apis/contrail/v1alpha1/templates/BUILD.bazel
+++ b/pkg/apis/contrail/v1alpha1/templates/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,6 +8,7 @@ go_library(
         "control_config.go",
         "kubemanager_config.go",
         "rabbitmq_config.go",
+        "templates_helper_functions.go",
         "vrouter_config.go",
         "webui_config.go",
         "zookeeper_config.go",
@@ -15,4 +16,11 @@ go_library(
     importpath = "github.com/Juniper/contrail-operator/pkg/apis/contrail/v1alpha1/templates",
     visibility = ["//visibility:public"],
     deps = ["@io_k8s_api//core/v1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["templates_helper_functions_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
@@ -28,6 +28,9 @@ func EndpointList(ips []string, port int) []string {
 }
 
 func EndpointListCommaSeparated(ips []string, port int) string {
+	if len(ips) == 0 {
+		return ""
+	}
 	portStr := strconv.Itoa(port)
 	endpointList := strings.Join(ips, ":"+portStr+",")
 	endpointList = endpointList + ":" + portStr
@@ -35,6 +38,9 @@ func EndpointListCommaSeparated(ips []string, port int) string {
 }
 
 func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
+	if len(ips) == 0 {
+		return ""
+	}
 	portStr := strconv.Itoa(port)
 	endpointList := strings.Join(ips, ":"+portStr+"','")
 	endpointList = "'" + endpointList + ":" + portStr + "'"
@@ -42,6 +48,9 @@ func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
 }
 
 func EndpointListSpaceSeparated(ips []string, port int) string {
+	if len(ips) == 0 {
+		return ""
+	}
 	portStr := strconv.Itoa(port)
 	endpointList := strings.Join(ips, ":"+portStr+" ")
 	endpointList = endpointList + ":" + portStr

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
@@ -5,21 +5,17 @@ import (
 	"strings"
 )
 
-func IPListCommaSeparated(ips []string) string {
-	return strings.Join(ips, ",")
+func JoinListWithSeparator(items []string, separator string) string {
+	return strings.Join(items, separator)
 }
 
-func IPListSpaceSeparated(ips []string) string {
-	return strings.Join(ips, " ")
-}
-
-func IPListCommaSeparatedQuoted(ips []string) string {
-	if len(ips) == 0 {
+func JoinListWithSeparatorAndSingleQuotes(items []string, separator string) string {
+	if len(items) == 0 {
 		return ""
 	}
-	endpointList := strings.Join(ips, "','")
-	endpointList = "'" + endpointList + "'"
-	return endpointList
+	joinedList := JoinListWithSeparator(items, "'"+separator+"'")
+	joinedList = "'" + joinedList + "'"
+	return joinedList
 }
 
 func EndpointList(ips []string, port int) []string {
@@ -29,32 +25,4 @@ func EndpointList(ips []string, port int) []string {
 		endpoints = append(endpoints, ip+":"+portStr)
 	}
 	return endpoints
-}
-
-func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
-	if len(ips) == 0 {
-		return ""
-	}
-	portStr := strconv.Itoa(port)
-	endpointList := strings.Join(ips, ":"+portStr+"','")
-	endpointList = "'" + endpointList + ":" + portStr + "'"
-	return endpointList
-}
-
-func EndpointListCommaSeparated(ips []string, port int) string {
-	return endpointListWithSeparator(ips, port, ",")
-}
-
-func EndpointListSpaceSeparated(ips []string, port int) string {
-	return endpointListWithSeparator(ips, port, " ")
-}
-
-func endpointListWithSeparator(ips []string, port int, separator string) string {
-	if len(ips) == 0 {
-		return ""
-	}
-	portStr := strconv.Itoa(port)
-	endpointList := strings.Join(ips, ":"+portStr+separator)
-	endpointList = endpointList + ":" + portStr
-	return endpointList
 }

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
@@ -27,16 +27,6 @@ func EndpointList(ips []string, port int) []string {
 	return endpoints
 }
 
-func EndpointListCommaSeparated(ips []string, port int) string {
-	if len(ips) == 0 {
-		return ""
-	}
-	portStr := strconv.Itoa(port)
-	endpointList := strings.Join(ips, ":"+portStr+",")
-	endpointList = endpointList + ":" + portStr
-	return endpointList
-}
-
 func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
 	if len(ips) == 0 {
 		return ""
@@ -47,12 +37,20 @@ func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
 	return endpointList
 }
 
+func EndpointListCommaSeparated(ips []string, port int) string {
+	return endpointListWithSeparator(ips, port, ",")
+}
+
 func EndpointListSpaceSeparated(ips []string, port int) string {
+	return endpointListWithSeparator(ips, port, " ")
+}
+
+func endpointListWithSeparator(ips []string, port int, separator string) string {
 	if len(ips) == 0 {
 		return ""
 	}
 	portStr := strconv.Itoa(port)
-	endpointList := strings.Join(ips, ":"+portStr+" ")
+	endpointList := strings.Join(ips, ":"+portStr+separator)
 	endpointList = endpointList + ":" + portStr
 	return endpointList
 }

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
@@ -9,6 +9,10 @@ func IPListCommaSeparated(ips []string) string {
 	return strings.Join(ips, ",")
 }
 
+func IPListSpaceSeparated(ips []string) string {
+	return strings.Join(ips, " ")
+}
+
 func IPListCommaSeparatedQuoted(ips []string) string {
 	if len(ips) == 0 {
 		return ""

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions.go
@@ -1,0 +1,49 @@
+package templates
+
+import (
+	"strconv"
+	"strings"
+)
+
+func IPListCommaSeparated(ips []string) string {
+	return strings.Join(ips, ",")
+}
+
+func IPListCommaSeparatedQuoted(ips []string) string {
+	if len(ips) == 0 {
+		return ""
+	}
+	endpointList := strings.Join(ips, "','")
+	endpointList = "'" + endpointList + "'"
+	return endpointList
+}
+
+func EndpointList(ips []string, port int) []string {
+	portStr := strconv.Itoa(port)
+	endpoints := []string{}
+	for _, ip := range ips {
+		endpoints = append(endpoints, ip+":"+portStr)
+	}
+	return endpoints
+}
+
+func EndpointListCommaSeparated(ips []string, port int) string {
+	portStr := strconv.Itoa(port)
+	endpointList := strings.Join(ips, ":"+portStr+",")
+	endpointList = endpointList + ":" + portStr
+	return endpointList
+}
+
+func EndpointListCommaSeparatedQuoted(ips []string, port int) string {
+	portStr := strconv.Itoa(port)
+	endpointList := strings.Join(ips, ":"+portStr+"','")
+	endpointList = "'" + endpointList + ":" + portStr + "'"
+	return endpointList
+}
+
+func EndpointListSpaceSeparated(ips []string, port int) string {
+	portStr := strconv.Itoa(port)
+	endpointList := strings.Join(ips, ":"+portStr+" ")
+	endpointList = endpointList + ":" + portStr
+	return endpointList
+}

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
@@ -75,17 +75,20 @@ func TestEndpointList(t *testing.T) {
 		{
 			name:           "Should return empty string for empty list.",
 			inputIpList:    []string{},
+			inputPort:      1234,
 			expectedOutput: []string{},
 		},
 		{
 			name:           "Shouldn't add commas to single ip and should add quotes",
 			inputIpList:    []string{"1.1.1.1"},
-			expectedOutput: []string{},
+			inputPort:      1234,
+			expectedOutput: []string{"1.1.1.1:1234"},
 		},
 		{
 			name:           "Should add commas between multiple ips",
 			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
-			expectedOutput: "'1.1.1.1','2.2.2.2','3.3.3.3'",
+			inputPort:      1234,
+			expectedOutput: []string{"1.1.1.1:1234", "2.2.2.2:1234", "3.3.3.3:1234"},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
@@ -1,0 +1,97 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPListCommaSeparated(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		expectedOutput string
+	}{
+		{
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			expectedOutput: "",
+		},
+		{
+			name:           "Shouldn't add commas to single ip.",
+			inputIpList:    []string{"1.1.1.1"},
+			expectedOutput: "1.1.1.1",
+		},
+		{
+			name:           "Should add commas between multiple ips",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			expectedOutput: "1.1.1.1,2.2.2.2,3.3.3.3",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := IPListCommaSeparated(test.inputIpList)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestIPListCommaSeparatedQuoted(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		expectedOutput string
+	}{
+		{
+			name:        "Should return empty string for empty list.",
+			inputIpList: []string{},
+		},
+		{
+			name:           "Shouldn't add commas to single ip and should add quotes",
+			inputIpList:    []string{"1.1.1.1"},
+			expectedOutput: "'1.1.1.1'",
+		},
+		{
+			name:           "Should add commas between multiple ips",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			expectedOutput: "'1.1.1.1','2.2.2.2','3.3.3.3'",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := IPListCommaSeparatedQuoted(test.inputIpList)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestEndpointList(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		inputPort      int
+		expectedOutput []string
+	}{
+		{
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			expectedOutput: []string{},
+		},
+		{
+			name:           "Shouldn't add commas to single ip and should add quotes",
+			inputIpList:    []string{"1.1.1.1"},
+			expectedOutput: []string{},
+		},
+		{
+			name:           "Should add commas between multiple ips",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			expectedOutput: "'1.1.1.1','2.2.2.2','3.3.3.3'",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := EndpointList(test.inputIpList, test.inputPort)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
@@ -6,60 +6,68 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIPListCommaSeparated(t *testing.T) {
+func TestJoinListWithSeparator(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputIpList    []string
+		inputSeparator string
 		expectedOutput string
 	}{
 		{
 			name:           "Should return empty string for empty list.",
 			inputIpList:    []string{},
+			inputSeparator: ",",
 			expectedOutput: "",
 		},
 		{
-			name:           "Shouldn't add commas to single ip.",
+			name:           "Shouldn't add separators to single ip.",
 			inputIpList:    []string{"1.1.1.1"},
+			inputSeparator: ",",
 			expectedOutput: "1.1.1.1",
 		},
 		{
-			name:           "Should add commas between multiple ips",
+			name:           "Should add separators between multiple ips",
 			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			inputSeparator: ",",
 			expectedOutput: "1.1.1.1,2.2.2.2,3.3.3.3",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualOutput := IPListCommaSeparated(test.inputIpList)
+			actualOutput := JoinListWithSeparator(test.inputIpList, test.inputSeparator)
 			assert.Equal(t, test.expectedOutput, actualOutput)
 		})
 	}
 }
 
-func TestIPListCommaSeparatedQuoted(t *testing.T) {
+func TestJoinListWithSeparatorAndSingleQuotes(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputIpList    []string
+		inputSeparator string
 		expectedOutput string
 	}{
 		{
-			name:        "Should return empty string for empty list.",
-			inputIpList: []string{},
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			inputSeparator: ",",
 		},
 		{
-			name:           "Shouldn't add commas to single ip and should add quotes",
+			name:           "Shouldn't add separators to single ip and should add quotes",
 			inputIpList:    []string{"1.1.1.1"},
+			inputSeparator: ",",
 			expectedOutput: "'1.1.1.1'",
 		},
 		{
-			name:           "Should add commas between multiple ips",
+			name:           "Should add separators between multiple ips",
 			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			inputSeparator: ",",
 			expectedOutput: "'1.1.1.1','2.2.2.2','3.3.3.3'",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualOutput := IPListCommaSeparatedQuoted(test.inputIpList)
+			actualOutput := JoinListWithSeparatorAndSingleQuotes(test.inputIpList, test.inputSeparator)
 			assert.Equal(t, test.expectedOutput, actualOutput)
 		})
 	}
@@ -94,108 +102,6 @@ func TestEndpointList(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actualOutput := EndpointList(test.inputIpList, test.inputPort)
-			assert.Equal(t, test.expectedOutput, actualOutput)
-		})
-	}
-}
-
-func TestEndpointListCommaSeparated(t *testing.T) {
-	tests := []struct {
-		name           string
-		inputIpList    []string
-		inputPort      int
-		expectedOutput string
-	}{
-		{
-			name:           "Should return empty string for empty list.",
-			inputIpList:    []string{},
-			inputPort:      1234,
-			expectedOutput: "",
-		},
-		{
-			name:           "Should return single endpoint for single IP, without commas",
-			inputIpList:    []string{"1.1.1.1"},
-			inputPort:      1234,
-			expectedOutput: "1.1.1.1:1234",
-		},
-		{
-			name:           "Should comma separated endpoints for multiple IPs",
-			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
-			inputPort:      1234,
-			expectedOutput: "1.1.1.1:1234,2.2.2.2:1234,3.3.3.3:1234",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualOutput := EndpointListCommaSeparated(test.inputIpList, test.inputPort)
-			assert.Equal(t, test.expectedOutput, actualOutput)
-		})
-	}
-}
-
-func TestEndpointListCommaSeparatedQuoted(t *testing.T) {
-	tests := []struct {
-		name           string
-		inputIpList    []string
-		inputPort      int
-		expectedOutput string
-	}{
-		{
-			name:           "Should return empty string for empty list.",
-			inputIpList:    []string{},
-			inputPort:      1234,
-			expectedOutput: "",
-		},
-		{
-			name:           "Should return single endpoint for single IP, without commas, but quoted.",
-			inputIpList:    []string{"1.1.1.1"},
-			inputPort:      1234,
-			expectedOutput: "'1.1.1.1:1234'",
-		},
-		{
-			name:           "Should comma separated and quoted endpoints for multiple IPs",
-			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
-			inputPort:      1234,
-			expectedOutput: "'1.1.1.1:1234','2.2.2.2:1234','3.3.3.3:1234'",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualOutput := EndpointListCommaSeparatedQuoted(test.inputIpList, test.inputPort)
-			assert.Equal(t, test.expectedOutput, actualOutput)
-		})
-	}
-}
-
-func TestEndpointListSpaceSeparated(t *testing.T) {
-	tests := []struct {
-		name           string
-		inputIpList    []string
-		inputPort      int
-		expectedOutput string
-	}{
-		{
-			name:           "Should return empty string for empty list.",
-			inputIpList:    []string{},
-			inputPort:      1234,
-			expectedOutput: "",
-		},
-		{
-			name:           "Should return single endpoint for single IP, without spaces",
-			inputIpList:    []string{"1.1.1.1"},
-			inputPort:      1234,
-			expectedOutput: "1.1.1.1:1234",
-		},
-		{
-			name:           "Should space separated endpoints for multiple IPs",
-			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
-			inputPort:      1234,
-			expectedOutput: "1.1.1.1:1234 2.2.2.2:1234 3.3.3.3:1234",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualOutput := EndpointListSpaceSeparated(test.inputIpList, test.inputPort)
 			assert.Equal(t, test.expectedOutput, actualOutput)
 		})
 	}

--- a/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
+++ b/pkg/apis/contrail/v1alpha1/templates/templates_helper_functions_test.go
@@ -73,19 +73,19 @@ func TestEndpointList(t *testing.T) {
 		expectedOutput []string
 	}{
 		{
-			name:           "Should return empty string for empty list.",
+			name:           "Should return empty slice for empty input slice.",
 			inputIpList:    []string{},
 			inputPort:      1234,
 			expectedOutput: []string{},
 		},
 		{
-			name:           "Shouldn't add commas to single ip and should add quotes",
+			name:           "Should return slice with single endpoint for single ip in input slice.",
 			inputIpList:    []string{"1.1.1.1"},
 			inputPort:      1234,
 			expectedOutput: []string{"1.1.1.1:1234"},
 		},
 		{
-			name:           "Should add commas between multiple ips",
+			name:           "Should return slice with multiple endpoints for multiple ips in input slice.",
 			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
 			inputPort:      1234,
 			expectedOutput: []string{"1.1.1.1:1234", "2.2.2.2:1234", "3.3.3.3:1234"},
@@ -94,6 +94,108 @@ func TestEndpointList(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actualOutput := EndpointList(test.inputIpList, test.inputPort)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestEndpointListCommaSeparated(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		inputPort      int
+		expectedOutput string
+	}{
+		{
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			inputPort:      1234,
+			expectedOutput: "",
+		},
+		{
+			name:           "Should return single endpoint for single IP, without commas",
+			inputIpList:    []string{"1.1.1.1"},
+			inputPort:      1234,
+			expectedOutput: "1.1.1.1:1234",
+		},
+		{
+			name:           "Should comma separated endpoints for multiple IPs",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			inputPort:      1234,
+			expectedOutput: "1.1.1.1:1234,2.2.2.2:1234,3.3.3.3:1234",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := EndpointListCommaSeparated(test.inputIpList, test.inputPort)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestEndpointListCommaSeparatedQuoted(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		inputPort      int
+		expectedOutput string
+	}{
+		{
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			inputPort:      1234,
+			expectedOutput: "",
+		},
+		{
+			name:           "Should return single endpoint for single IP, without commas, but quoted.",
+			inputIpList:    []string{"1.1.1.1"},
+			inputPort:      1234,
+			expectedOutput: "'1.1.1.1:1234'",
+		},
+		{
+			name:           "Should comma separated and quoted endpoints for multiple IPs",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			inputPort:      1234,
+			expectedOutput: "'1.1.1.1:1234','2.2.2.2:1234','3.3.3.3:1234'",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := EndpointListCommaSeparatedQuoted(test.inputIpList, test.inputPort)
+			assert.Equal(t, test.expectedOutput, actualOutput)
+		})
+	}
+}
+
+func TestEndpointListSpaceSeparated(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputIpList    []string
+		inputPort      int
+		expectedOutput string
+	}{
+		{
+			name:           "Should return empty string for empty list.",
+			inputIpList:    []string{},
+			inputPort:      1234,
+			expectedOutput: "",
+		},
+		{
+			name:           "Should return single endpoint for single IP, without spaces",
+			inputIpList:    []string{"1.1.1.1"},
+			inputPort:      1234,
+			expectedOutput: "1.1.1.1:1234",
+		},
+		{
+			name:           "Should space separated endpoints for multiple IPs",
+			inputIpList:    []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			inputPort:      1234,
+			expectedOutput: "1.1.1.1:1234 2.2.2.2:1234 3.3.3.3:1234",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualOutput := EndpointListSpaceSeparated(test.inputIpList, test.inputPort)
 			assert.Equal(t, test.expectedOutput, actualOutput)
 		})
 	}

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -337,6 +337,9 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 			gateway = vrouterConfig.Gateway
 		}
 
+		controlXMPPEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.XMPPPort)
+		controlDNSEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.DNSPort)
+		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
 		var vrouterConfigBuffer bytes.Buffer
 		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
 			Hostname             string
@@ -353,9 +356,9 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		}{
 			Hostname:             hostname,
 			ListenAddress:        podList.Items[idx].Status.PodIP,
-			ControlServerList:    controlNodesInformation.ServerListXMPPSpaceSeparated,
-			DNSServerList:        controlNodesInformation.ServerListDNSSpaceSeparated,
-			CollectorServerList:  configNodesInformation.CollectorServerListSpaceSeparated,
+			ControlServerList:    controlXMPPEndpointListSpaceSeparated,
+			DNSServerList:        controlDNSEndpointListSpaceSeparated,
+			CollectorServerList:  configCollectorEndpointListSpaceSeparated,
 			PrefixLength:         prefixLength,
 			PhysicalInterface:    physicalInterface,
 			PhysicalInterfaceMac: physicalInterfaceMac,
@@ -376,7 +379,7 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 		}{
 			ListenAddress:       podList.Items[idx].Status.PodIP,
 			Hostname:            hostname,
-			CollectorServerList: configNodesInformation.CollectorServerListSpaceSeparated,
+			CollectorServerList: configCollectorEndpointListSpaceSeparated,
 			CassandraPort:       cassandraNodesInformation.CQLPort,
 			CassandraJmxPort:    cassandraNodesInformation.JMXPort,
 			CAFilePath:          certificates.SignerCAFilepath,

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -56,27 +56,19 @@ type VrouterSpec struct {
 // VrouterConfiguration is the Spec for the cassandras API.
 // +k8s:openapi-gen=true
 type VrouterConfiguration struct {
-	Containers          []*Container                `json:"containers,omitempty"`
-	ControlInstance     string                      `json:"controlInstance,omitempty"`
-	CassandraInstance   string                      `json:"cassandraInstance,omitempty"`
-	Gateway             string                      `json:"gateway,omitempty"`
-	PhysicalInterface   string                      `json:"physicalInterface,omitempty"`
-	MetaDataSecret      string                      `json:"metaDataSecret,omitempty"`
-	NodeManager         *bool                       `json:"nodeManager,omitempty"`
-	Distribution        *Distribution               `json:"distribution,omitempty"`
-	ServiceAccount      string                      `json:"serviceAccount,omitempty"`
-	ClusterRole         string                      `json:"clusterRole,omitempty"`
-	ClusterRoleBinding  string                      `json:"clusterRoleBinding,omitempty"`
-	VrouterEncryption   bool                        `json:"vrouterEncryption,omitempty"`
-	ContrailStatusImage string                      `json:"contrailStatusImage,omitempty"`
-	StaticConfiguration *VrouterStaticConfiguration `json:"staticConfiguration,omitempty"`
-}
-
-// +k8s:openapi-gen=true
-type VrouterStaticConfiguration struct {
-	ControlNodesIPs   []string `json:"controlNodesIPs,omitempty"`
-	ConfigNodesIPs    []string `json:"configNodesIPs,omitempty"`
-	CassandraNodesIPs []string `json:"cassandraNodesIPs,omitempty"`
+	Containers          []*Container  `json:"containers,omitempty"`
+	ControlInstance     string        `json:"controlInstance,omitempty"`
+	CassandraInstance   string        `json:"cassandraInstance,omitempty"`
+	Gateway             string        `json:"gateway,omitempty"`
+	PhysicalInterface   string        `json:"physicalInterface,omitempty"`
+	MetaDataSecret      string        `json:"metaDataSecret,omitempty"`
+	NodeManager         *bool         `json:"nodeManager,omitempty"`
+	Distribution        *Distribution `json:"distribution,omitempty"`
+	ServiceAccount      string        `json:"serviceAccount,omitempty"`
+	ClusterRole         string        `json:"clusterRole,omitempty"`
+	ClusterRoleBinding  string        `json:"clusterRoleBinding,omitempty"`
+	VrouterEncryption   bool          `json:"vrouterEncryption,omitempty"`
+	ContrailStatusImage string        `json:"contrailStatusImage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -298,37 +290,128 @@ func (c *Vrouter) PodIPListAndIPMapFromInstance(instanceType string, request rec
 func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	podList *corev1.PodList,
 	client client.Client) error {
+	instanceConfigMapName := request.Name + "-" + "vrouter" + "-configmap"
+	configMapInstanceDynamicConfig := &corev1.ConfigMap{}
+	err := client.Get(context.TODO(),
+		types.NamespacedName{Name: instanceConfigMapName, Namespace: request.Namespace},
+		configMapInstanceDynamicConfig)
+	if err != nil {
+		return err
+	}
 
-	// TODO(psykulsk) - create an intermediary function that will check if there is static config
 	configNodesInformation, err := NewConfigClusterConfiguration(c.Labels["contrail_cluster"],
 		request.Namespace, client)
 	if err != nil {
 		return err
 	}
-	// TODO(psykulsk) - create an intermediary function that will check if there is static config
 	controlNodesInformation, err := NewControlClusterConfiguration(c.Spec.ServiceConfiguration.ControlInstance,
 		"", request.Namespace, client)
 	if err != nil {
 		return err
 	}
-
-	instanceConfigMapName := request.Name + "-" + "vrouter" + "-configmap"
-	configMapInstanceDynamicConfig := &corev1.ConfigMap{}
-	if err = client.Get(context.TODO(), types.NamespacedName{Name: instanceConfigMapName, Namespace: request.Namespace}, configMapInstanceDynamicConfig); err != nil {
+	cassandraNodesInformation, err := NewCassandraClusterConfiguration(c.Spec.ServiceConfiguration.CassandraInstance,
+		request.Namespace, client)
+	if err != nil {
 		return err
 	}
-	configMapInstanceDynamicConfig.Data = c.createVrouterDynamicConfig(podList, controlNodesInformation, configNodesInformation)
-	if err = client.Update(context.TODO(), configMapInstanceDynamicConfig); err != nil {
+
+	vrouterConfigInstance := c.ConfigurationParameters()
+	vrouterConfig := vrouterConfigInstance.(VrouterConfiguration)
+
+	var podIPList []string
+	for _, pod := range podList.Items {
+		podIPList = append(podIPList, pod.Status.PodIP)
+	}
+	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
+	var data = make(map[string]string)
+	for idx := range podList.Items {
+		hostname := podList.Items[idx].Annotations["hostname"]
+		physicalInterfaceMac := podList.Items[idx].Annotations["physicalInterfaceMac"]
+		prefixLength := podList.Items[idx].Annotations["prefixLength"]
+		physicalInterface := podList.Items[idx].Annotations["physicalInterface"]
+		gateway := podList.Items[idx].Annotations["gateway"]
+		if vrouterConfig.PhysicalInterface != "" {
+			physicalInterface = vrouterConfig.PhysicalInterface
+		}
+		if vrouterConfig.Gateway != "" {
+			gateway = vrouterConfig.Gateway
+		}
+
+		var vrouterConfigBuffer bytes.Buffer
+		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
+			Hostname             string
+			ListenAddress        string
+			ControlServerList    string
+			DNSServerList        string
+			CollectorServerList  string
+			PrefixLength         string
+			PhysicalInterface    string
+			PhysicalInterfaceMac string
+			Gateway              string
+			MetaDataSecret       string
+			CAFilePath           string
+		}{
+			Hostname:             hostname,
+			ListenAddress:        podList.Items[idx].Status.PodIP,
+			ControlServerList:    controlNodesInformation.ServerListXMPPSpaceSeparated,
+			DNSServerList:        controlNodesInformation.ServerListDNSSpaceSeparated,
+			CollectorServerList:  configNodesInformation.CollectorServerListSpaceSeparated,
+			PrefixLength:         prefixLength,
+			PhysicalInterface:    physicalInterface,
+			PhysicalInterfaceMac: physicalInterfaceMac,
+			Gateway:              gateway,
+			MetaDataSecret:       vrouterConfig.MetaDataSecret,
+			CAFilePath:           certificates.SignerCAFilepath,
+		})
+		data["vrouter."+podList.Items[idx].Status.PodIP] = vrouterConfigBuffer.String()
+
+		var vrouterNodemanagerBuffer bytes.Buffer
+		configtemplates.VrouterNodemanagerConfig.Execute(&vrouterNodemanagerBuffer, struct {
+			ListenAddress       string
+			Hostname            string
+			CollectorServerList string
+			CassandraPort       string
+			CassandraJmxPort    string
+			CAFilePath          string
+		}{
+			ListenAddress:       podList.Items[idx].Status.PodIP,
+			Hostname:            hostname,
+			CollectorServerList: configNodesInformation.CollectorServerListSpaceSeparated,
+			CassandraPort:       cassandraNodesInformation.CQLPort,
+			CassandraJmxPort:    cassandraNodesInformation.JMXPort,
+			CAFilePath:          certificates.SignerCAFilepath,
+		})
+		data["nodemanager."+podList.Items[idx].Status.PodIP] = vrouterNodemanagerBuffer.String()
+	}
+	configMapInstanceDynamicConfig.Data = data
+	err = client.Update(context.TODO(), configMapInstanceDynamicConfig)
+	if err != nil {
 		return err
 	}
 
 	envVariablesConfigMapName := request.Name + "-" + "vrouter" + "-configmap-1"
 	envVariablesConfigMap := &corev1.ConfigMap{}
-	if err = client.Get(context.TODO(), types.NamespacedName{Name: envVariablesConfigMapName, Namespace: request.Namespace}, envVariablesConfigMap); err != nil {
+	err = client.Get(context.TODO(),
+		types.NamespacedName{Name: envVariablesConfigMapName, Namespace: request.Namespace},
+		envVariablesConfigMap)
+	if err != nil {
 		return err
 	}
-	envVariablesConfigMap.Data = c.getVrouterEnvironmentData()
-	return client.Update(context.TODO(), envVariablesConfigMap)
+
+	var envVariables = make(map[string]string)
+	envVariables["CLOUD_ORCHESTRATOR"] = "kubernetes"
+	envVariables["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
+	// If PhysicalInterface is set, environment variable from the config map will
+	// override the value from the annotations.
+	if vrouterConfig.PhysicalInterface != "" {
+		envVariables["PHYSICAL_INTERFACE"] = vrouterConfig.PhysicalInterface
+	}
+	envVariablesConfigMap.Data = envVariables
+	err = client.Update(context.TODO(), envVariablesConfigMap)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetPodsToReady sets Kubemanager PODs to ready.
@@ -348,7 +431,7 @@ func (c *Vrouter) ManageNodeStatus(podNameIPMap map[string]string,
 }
 
 // ConfigurationParameters is a method for gathering data used in rendering vRouter configuration
-func (c *Vrouter) ConfigurationParameters() VrouterConfiguration {
+func (c *Vrouter) ConfigurationParameters() interface{} {
 	vrouterConfiguration := VrouterConfiguration{}
 	var physicalInterface string
 	var gateway string
@@ -380,73 +463,4 @@ func (c *Vrouter) ConfigurationParameters() VrouterConfiguration {
 	vrouterConfiguration.MetaDataSecret = metaDataSecret
 
 	return vrouterConfiguration
-}
-
-func (c *Vrouter) getVrouterEnvironmentData() map[string]string {
-	vrouterConfig := c.ConfigurationParameters()
-	envVariables := make(map[string]string)
-	envVariables["CLOUD_ORCHESTRATOR"] = "kubernetes"
-	envVariables["VROUTER_ENCRYPTION"] = strconv.FormatBool(vrouterConfig.VrouterEncryption)
-	// If PhysicalInterface is set, environment variable from the config map will
-	// override the value from the annotations.
-	if vrouterConfig.PhysicalInterface != "" {
-		envVariables["PHYSICAL_INTERFACE"] = vrouterConfig.PhysicalInterface
-	}
-	return envVariables
-}
-
-func (c *Vrouter) createVrouterDynamicConfig(podList *corev1.PodList,
-	controlNodesInformation *ControlClusterConfiguration,
-	configNodesInformation *ConfigClusterConfiguration) map[string]string {
-	vrouterConfig := c.ConfigurationParameters()
-	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
-	data := map[string]string{}
-	for _, vrouterPod := range podList.Items {
-		data["vrouter."+vrouterPod.Status.PodIP] = createVrouterConfigForPod(&vrouterPod, vrouterConfig, controlNodesInformation, configNodesInformation)
-	}
-	return data
-}
-
-func createVrouterConfigForPod(vrouterPod *corev1.Pod, vrouterConfig VrouterConfiguration, controlNodesInformation *ControlClusterConfiguration, configNodesInformation *ConfigClusterConfiguration) string {
-	hostname := vrouterPod.Annotations["hostname"]
-	physicalInterfaceMac := vrouterPod.Annotations["physicalInterfaceMac"]
-	prefixLength := vrouterPod.Annotations["prefixLength"]
-	physicalInterface := vrouterPod.Annotations["physicalInterface"]
-	gateway := vrouterPod.Annotations["gateway"]
-	if vrouterConfig.PhysicalInterface != "" {
-		physicalInterface = vrouterConfig.PhysicalInterface
-	}
-	if vrouterConfig.Gateway != "" {
-		gateway = vrouterConfig.Gateway
-	}
-	controlXMPPEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.XMPPPort)
-	controlDNSEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.DNSPort)
-	configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
-	var vrouterConfigBuffer bytes.Buffer
-	configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
-		Hostname             string
-		ListenAddress        string
-		ControlServerList    string
-		DNSServerList        string
-		CollectorServerList  string
-		PrefixLength         string
-		PhysicalInterface    string
-		PhysicalInterfaceMac string
-		Gateway              string
-		MetaDataSecret       string
-		CAFilePath           string
-	}{
-		Hostname:             hostname,
-		ListenAddress:        vrouterPod.Status.PodIP,
-		ControlServerList:    controlXMPPEndpointListSpaceSeparated,
-		DNSServerList:        controlDNSEndpointListSpaceSeparated,
-		CollectorServerList:  configCollectorEndpointListSpaceSeparated,
-		PrefixLength:         prefixLength,
-		PhysicalInterface:    physicalInterface,
-		PhysicalInterfaceMac: physicalInterfaceMac,
-		Gateway:              gateway,
-		MetaDataSecret:       vrouterConfig.MetaDataSecret,
-		CAFilePath:           certificates.SignerCAFilepath,
-	})
-	return vrouterConfigBuffer.String()
 }

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -72,6 +72,7 @@ type VrouterConfiguration struct {
 	StaticConfiguration *VrouterStaticConfiguration `json:"staticConfiguration,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 type VrouterStaticConfiguration struct {
 	ControlNodesIPs   []string `json:"controlNodesIPs,omitempty"`
 	ConfigNodesIPs    []string `json:"configNodesIPs,omitempty"`
@@ -298,11 +299,13 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	podList *corev1.PodList,
 	client client.Client) error {
 
+	// TODO(psykulsk) - create an intermediary function that will check if there is static config
 	configNodesInformation, err := NewConfigClusterConfiguration(c.Labels["contrail_cluster"],
 		request.Namespace, client)
 	if err != nil {
 		return err
 	}
+	// TODO(psykulsk) - create an intermediary function that will check if there is static config
 	controlNodesInformation, err := NewControlClusterConfiguration(c.Spec.ServiceConfiguration.ControlInstance,
 		"", request.Namespace, client)
 	if err != nil {
@@ -314,7 +317,6 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 	if err = client.Get(context.TODO(), types.NamespacedName{Name: instanceConfigMapName, Namespace: request.Namespace}, configMapInstanceDynamicConfig); err != nil {
 		return err
 	}
-	// TODO - getVrouterDynamicConfigData should accept interfaces of nodes information
 	configMapInstanceDynamicConfig.Data = c.createVrouterDynamicConfig(podList, controlNodesInformation, configNodesInformation)
 	if err = client.Update(context.TODO(), configMapInstanceDynamicConfig); err != nil {
 		return err

--- a/pkg/apis/contrail/v1alpha1/vrouter_types.go
+++ b/pkg/apis/contrail/v1alpha1/vrouter_types.go
@@ -337,9 +337,12 @@ func (c *Vrouter) InstanceConfiguration(request reconcile.Request,
 			gateway = vrouterConfig.Gateway
 		}
 
-		controlXMPPEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.XMPPPort)
-		controlDNSEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(controlNodesInformation.ControlServerIPList, controlNodesInformation.DNSPort)
-		configCollectorEndpointListSpaceSeparated := configtemplates.EndpointListSpaceSeparated(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		controlXMPPEndpointList := configtemplates.EndpointList(controlNodesInformation.ControlServerIPList, controlNodesInformation.XMPPPort)
+		controlXMPPEndpointListSpaceSeparated := configtemplates.JoinListWithSeparator(controlXMPPEndpointList, " ")
+		controlDNSEndpointList := configtemplates.EndpointList(controlNodesInformation.ControlServerIPList, controlNodesInformation.DNSPort)
+		controlDNSEndpointListSpaceSeparated := configtemplates.JoinListWithSeparator(controlDNSEndpointList, " ")
+		configCollectorEndpointList := configtemplates.EndpointList(configNodesInformation.CollectorServerIPList, configNodesInformation.CollectorPort)
+		configCollectorEndpointListSpaceSeparated := configtemplates.JoinListWithSeparator(configCollectorEndpointList, " ")
 		var vrouterConfigBuffer bytes.Buffer
 		configtemplates.VRouterConfig.Execute(&vrouterConfigBuffer, struct {
 			Hostname             string

--- a/pkg/apis/contrail/v1alpha1/webui_types.go
+++ b/pkg/apis/contrail/v1alpha1/webui_types.go
@@ -149,7 +149,7 @@ func (c *Webui) InstanceConfiguration(request reconcile.Request,
 		}
 	}
 
-	configApiIPListCommeSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
+	configApiIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
 	analyticsIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.AnalyticsServerIPList)
 	controlXMPPIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(controlNodesInformation.ControlServerIPList)
 	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
@@ -181,7 +181,7 @@ func (c *Webui) InstanceConfiguration(request reconcile.Request,
 		}{
 			HostIP:                 podList.Items[idx].Status.PodIP,
 			Hostname:               podList.Items[idx].Name,
-			APIServerList:          configApiIPListCommeSeparatedQuoted,
+			APIServerList:          configApiIPListCommaSeparatedQuoted,
 			APIServerPort:          strconv.Itoa(configNodesInformation.APIServerPort),
 			AnalyticsServerList:    analyticsIPListCommaSeparatedQuoted,
 			AnalyticsServerPort:    strconv.Itoa(configNodesInformation.AnalyticsServerPort),

--- a/pkg/apis/contrail/v1alpha1/webui_types.go
+++ b/pkg/apis/contrail/v1alpha1/webui_types.go
@@ -149,9 +149,9 @@ func (c *Webui) InstanceConfiguration(request reconcile.Request,
 		}
 	}
 
-	configApiIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
-	analyticsIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.AnalyticsServerIPList)
-	controlXMPPIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(controlNodesInformation.ControlServerIPList)
+	configApiIPListCommaSeparatedQuoted := configtemplates.JoinListWithSeparatorAndSingleQuotes(configNodesInformation.APIServerIPList, ",")
+	analyticsIPListCommaSeparatedQuoted := configtemplates.JoinListWithSeparatorAndSingleQuotes(configNodesInformation.AnalyticsServerIPList, ",")
+	controlXMPPIPListCommaSeparatedQuoted := configtemplates.JoinListWithSeparatorAndSingleQuotes(controlNodesInformation.ControlServerIPList, ",")
 	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
 	var data = make(map[string]string)
 	for idx := range podList.Items {

--- a/pkg/apis/contrail/v1alpha1/webui_types.go
+++ b/pkg/apis/contrail/v1alpha1/webui_types.go
@@ -149,10 +149,9 @@ func (c *Webui) InstanceConfiguration(request reconcile.Request,
 		}
 	}
 
-	var podIPList []string
-	for _, pod := range podList.Items {
-		podIPList = append(podIPList, pod.Status.PodIP)
-	}
+	configApiIPListCommeSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.APIServerIPList)
+	analyticsIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(configNodesInformation.AnalyticsServerIPList)
+	controlXMPPIPListCommaSeparatedQuoted := configtemplates.IPListCommaSeparatedQuoted(controlNodesInformation.ControlServerIPList)
 	sort.SliceStable(podList.Items, func(i, j int) bool { return podList.Items[i].Status.PodIP < podList.Items[j].Status.PodIP })
 	var data = make(map[string]string)
 	for idx := range podList.Items {
@@ -182,12 +181,12 @@ func (c *Webui) InstanceConfiguration(request reconcile.Request,
 		}{
 			HostIP:                 podList.Items[idx].Status.PodIP,
 			Hostname:               podList.Items[idx].Name,
-			APIServerList:          configNodesInformation.APIServerListQuotedCommaSeparated,
-			APIServerPort:          configNodesInformation.APIServerPort,
-			AnalyticsServerList:    configNodesInformation.AnalyticsServerListQuotedCommaSeparated,
-			AnalyticsServerPort:    configNodesInformation.AnalyticsServerPort,
-			ControlNodeList:        controlNodesInformation.ServerListCommanSeparatedQuoted,
-			DnsNodePort:            controlNodesInformation.DNSIntrospectPort,
+			APIServerList:          configApiIPListCommeSeparatedQuoted,
+			APIServerPort:          strconv.Itoa(configNodesInformation.APIServerPort),
+			AnalyticsServerList:    analyticsIPListCommaSeparatedQuoted,
+			AnalyticsServerPort:    strconv.Itoa(configNodesInformation.AnalyticsServerPort),
+			ControlNodeList:        controlXMPPIPListCommaSeparatedQuoted,
+			DnsNodePort:            strconv.Itoa(controlNodesInformation.DNSIntrospectPort),
 			CassandraServerList:    cassandraNodesInformation.ServerListCommanSeparatedQuoted,
 			CassandraPort:          cassandraNodesInformation.CQLPort,
 			RedisServerList:        "127.0.0.1",


### PR DESCRIPTION
I modified the ControlClusterConfiguration and ConfigClusterConfiguration structures. Before, different strings containing formatted lists of IPs or endpoints were stored in the struct (comma separated, space separated, comma separated with quotes etc.).  

I modified it so that only the actual data is stored in the struct and strings in the required formats are generated just before the template is executed (using helper functions), so only the relevant data is passed in the struct. 

I believe that it simplifies the code and will also make it easier to add the static configuration capabilities to different custom resources.

In future PRs other ClusterConfiguration structs will be similarly refactored.