### PR TITLE
Remove invalid owner references

### DIFF
--- a/pkg/apis/contrail/v1alpha1/base_types.go
+++ b/pkg/apis/contrail/v1alpha1/base_types.go
@@ -206,10 +206,6 @@ func CreateAccount(accountName string, namespace string, client client.Client, s
 				},
 			}},
 		}
-		err = controllerutil.SetControllerReference(owner, clusterRole, scheme)
-		if err != nil {
-			return err
-		}
 		if err = client.Create(context.TODO(), clusterRole); err != nil {
 			return err
 		}
@@ -237,10 +233,6 @@ func CreateAccount(accountName string, namespace string, client client.Client, s
 				Kind:     "ClusterRole",
 				Name:     clusterRoleName,
 			},
-		}
-		err = controllerutil.SetControllerReference(owner, clusterRoleBinding, scheme)
-		if err != nil {
-			return err
 		}
 		if err = client.Create(context.TODO(), clusterRoleBinding); err != nil {
 			return err

--- a/pkg/controller/kubemanager/kubemanager_controller.go
+++ b/pkg/controller/kubemanager/kubemanager_controller.go
@@ -361,10 +361,6 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 				},
 			}},
 		}
-		err = controllerutil.SetControllerReference(instance, clusterRole, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		if err = r.Client.Create(context.TODO(), clusterRole); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -392,10 +388,6 @@ func (r *ReconcileKubemanager) Reconcile(request reconcile.Request) (reconcile.R
 				Kind:     "ClusterRole",
 				Name:     clusterRoleName,
 			},
-		}
-		err = controllerutil.SetControllerReference(instance, clusterRoleBinding, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
 		}
 		if err = r.Client.Create(context.TODO(), clusterRoleBinding); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/vrouter/vrouter_controller.go
+++ b/pkg/controller/vrouter/vrouter_controller.go
@@ -290,10 +290,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 				},
 			}},
 		}
-		err = controllerutil.SetControllerReference(instance, clusterRole, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		if err = r.Client.Create(context.TODO(), clusterRole); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -321,10 +317,6 @@ func (r *ReconcileVrouter) Reconcile(request reconcile.Request) (reconcile.Resul
 				Kind:     "ClusterRole",
 				Name:     clusterRoleName,
 			},
-		}
-		err = controllerutil.SetControllerReference(instance, clusterRoleBinding, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
 		}
 		if err = r.Client.Create(context.TODO(), clusterRoleBinding); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/webui/webui_controller.go
+++ b/pkg/controller/webui/webui_controller.go
@@ -305,10 +305,6 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 				},
 			}},
 		}
-		err = controllerutil.SetControllerReference(instance, clusterRole, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		if err = r.Client.Create(context.TODO(), clusterRole); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -336,10 +332,6 @@ func (r *ReconcileWebui) Reconcile(request reconcile.Request) (reconcile.Result,
 				Kind:     "ClusterRole",
 				Name:     clusterRoleName,
 			},
-		}
-		err = controllerutil.SetControllerReference(instance, clusterRoleBinding, r.Scheme)
-		if err != nil {
-			return reconcile.Result{}, err
 		}
 		if err = r.Client.Create(context.TODO(), clusterRoleBinding); err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
Resources created by our controllers are still sometimes being deleted by the kubernetes garbage collector. The cause is the same as with this PR https://github.com/Juniper/contrail-operator/pull/277 , please refer to the description there. But this time the owner references are set on the ClusterRole and ClusterRoleBinding objects which are cluster-scoped, so they can't have an namespace scoped owner like our CustomResources.

To trigger the garbage collection kill the pid 1 process inside all kube-controller-manager containers:
On Openshift:
```
kubectl get pod -n openshift-kube-controller-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep kube-controller-manager-ip | xargs -I% kubectl exec -n openshift-kube-controller-manager % bash -- -c 'kill 1'
```

On kind (do it for all replicas):
```
kubectl exec -it -n kube-system     kube-controller-manager-kind-control-plane sh -- -c 'kill 1'
```