### PR TITLE
Change external traffic policy from cluster to local

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -59,6 +59,8 @@ func (s *Service) EnsureExists() error {
 		s.svc.Spec.Ports = servicePortList
 		s.svc.Spec.Selector = labels
 		s.svc.Spec.Type = s.servType
+		// Some of the services are not working well with default (Cluster) ExternalTrafficPolicy
+		s.svc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyTypeLocal
 		return controllerutil.SetControllerReference(s.owner, &s.svc, s.scheme)
 	})
 	return err

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -59,8 +59,10 @@ func (s *Service) EnsureExists() error {
 		s.svc.Spec.Ports = servicePortList
 		s.svc.Spec.Selector = labels
 		s.svc.Spec.Type = s.servType
-		// Some of the services are not working well with default (Cluster) ExternalTrafficPolicy
-		s.svc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyTypeLocal
+		if s.svc.Spec.Type == core.ServiceTypeLoadBalancer {
+			// Some of the services in the clusterare not working well with default (Cluster) ExternalTrafficPolicy
+			s.svc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyTypeLocal
+		}
 		return controllerutil.SetControllerReference(s.owner, &s.svc, s.scheme)
 	})
 	return err

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -35,8 +35,7 @@ func TestEnsureServiceExists(t *testing.T) {
 				Ports: []core.ServicePort{{
 					Name: "", Protocol: "TCP", Port: 5555,
 				}},
-				Selector:              map[string]string{"contrail_manager": "pod", "pod": "owner"},
-				ExternalTrafficPolicy: core.ServiceExternalTrafficPolicyTypeLocal,
+				Selector: map[string]string{"contrail_manager": "pod", "pod": "owner"},
 			},
 		},
 		{

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -35,7 +35,8 @@ func TestEnsureServiceExists(t *testing.T) {
 				Ports: []core.ServicePort{{
 					Name: "", Protocol: "TCP", Port: 5555,
 				}},
-				Selector: map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				Selector:              map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				ExternalTrafficPolicy: core.ServiceExternalTrafficPolicyTypeLocal,
 			},
 		},
 		{
@@ -47,7 +48,8 @@ func TestEnsureServiceExists(t *testing.T) {
 				Ports: []core.ServicePort{{
 					Name: "", Protocol: "TCP", Port: 5555,
 				}},
-				Selector: map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				Selector:              map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				ExternalTrafficPolicy: core.ServiceExternalTrafficPolicyTypeLocal,
 			},
 		},
 		{
@@ -59,7 +61,8 @@ func TestEnsureServiceExists(t *testing.T) {
 				Ports: []core.ServicePort{{
 					Name: "", Protocol: "TCP", Port: 5555, NodePort: 30000,
 				}},
-				Selector: map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				Selector:              map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				ExternalTrafficPolicy: core.ServiceExternalTrafficPolicyTypeLocal,
 			},
 			initDBState: []runtime.Object{
 				&core.Service{
@@ -77,7 +80,8 @@ func TestEnsureServiceExists(t *testing.T) {
 				Ports: []core.ServicePort{{
 					Name: "", Protocol: "TCP", Port: 5500,
 				}},
-				Selector: map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				Selector:              map[string]string{"contrail_manager": "pod", "pod": "owner"},
+				ExternalTrafficPolicy: core.ServiceExternalTrafficPolicyTypeLocal,
 			},
 			initDBState: []runtime.Object{
 				&core.Service{


### PR DESCRIPTION
It looks like default traffic policy is not working correctly for some of the services in CNI less k8s environment.
For now local policy is going to be used.