### PR TITLE
Rename crdsloader and ringcontroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ In order to run Contrail-Operator in the Kubernetes cluster we have to build Doc
     # local registry address
     export LOCAL_REGISTRY=localhost:5000
 
-    # it builds and pushes image: {LOCAL_REGISTRY}/contrail-operator/engprod-269421/crdsloader:master.latest
-    bazel run //cmd/crdsloader:crdsloader-push-local
+    # it builds and pushes image: {LOCAL_REGISTRY}/contrail-operator/engprod-269421/contrail-operator-crdsloader:master.latest
+    bazel run //cmd/crdsloader:contrail-operator-crdsloader-push-local
 
     # it builds and pushes image: {LOCAL_REGISTRY}/contrail-operator/engprod-269421/contrail-operator:master.latest
     bazel run //cmd/manager:contrail-operator-push-local-debug

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,12 +92,12 @@ load(
 pip_repositories()
 
 pip3_import(
-    name = "ringcontroller",
+    name = "contrail-operator-ringcontroller",
     extra_pip_args = ["--no-deps"],
     requirements = "//ringcontroller:requirements.txt",
 )
 
-load("@ringcontroller//:requirements.bzl", ringbuilder_pip_install = "pip_install")
+load("@contrail-operator-ringcontroller//:requirements.bzl", ringbuilder_pip_install = "pip_install")
 
 ringbuilder_pip_install()
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,7 +40,7 @@ steps:
       - TAG_NAME=$TAG_NAME
       - REVISION_ID=$REVISION_ID
   - name: "gcr.io/cloud-builders/bazel"
-    args: ["run", "//cmd/crdsloader:crdsloader-push"]
+    args: ["run", "//cmd/crdsloader:contrail-operator-crdsloader-push"]
     env:
       - BUILD_ID=$BUILD_ID
       - COMMIT_SHA=$COMMIT_SHA
@@ -50,7 +50,7 @@ steps:
       - TAG_NAME=$TAG_NAME
       - REVISION_ID=$REVISION_ID
   - name: "gcr.io/cloud-builders/bazel"
-    args: ["run", "//cmd/crdsloader:crdsloader-push-latest"]
+    args: ["run", "//cmd/crdsloader:contrail-operator-crdsloader-push-latest"]
     env:
       - BUILD_ID=$BUILD_ID
       - COMMIT_SHA=$COMMIT_SHA
@@ -100,7 +100,7 @@ steps:
       - TAG_NAME=$TAG_NAME
       - REVISION_ID=$REVISION_ID
   - name: "gcr.io/cloud-builders/bazel"
-    args: ["run", "//ringcontroller:ringcontroller-push"]
+    args: ["run", "//ringcontroller:contrail-operator-ringcontroller-push"]
     env:
       - BUILD_ID=$BUILD_ID
       - COMMIT_SHA=$COMMIT_SHA
@@ -110,7 +110,7 @@ steps:
       - TAG_NAME=$TAG_NAME
       - REVISION_ID=$REVISION_ID
   - name: "gcr.io/cloud-builders/bazel"
-    args: ["run", "//ringcontroller:ringcontroller-push-latest"]
+    args: ["run", "//ringcontroller:contrail-operator-ringcontroller-push-latest"]
     env:
       - BUILD_ID=$BUILD_ID
       - COMMIT_SHA=$COMMIT_SHA

--- a/cmd/crdsloader/BUILD.bazel
+++ b/cmd/crdsloader/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
 container_image(
-    name = "crdsloader-crds-layer",
+    name = "contrail-operator-crdsloader-crds-layer",
     base = "@go_debug_image_base//image:image",
     directory = "/crds",
     files = [
@@ -10,8 +10,8 @@ container_image(
 )
 
 container_image(
-    name = "crdsloader-image",
-    base = ":crdsloader-crds-layer",
+    name = "contrail-operator-crdsloader-image",
+    base = ":contrail-operator-crdsloader-crds-layer",
     directory = "/app",
     entrypoint = [
         "sh",
@@ -25,28 +25,28 @@ container_image(
 )
 
 container_push(
-    name = "crdsloader-push-local",
+    name = "contrail-operator-crdsloader-push-local",
     format = "Docker",
-    image = ":crdsloader-image",
+    image = ":contrail-operator-crdsloader-image",
     registry = "{LOCAL_REGISTRY}",
-    repository = "contrail-operator/engprod-269421/crdsloader",
+    repository = "contrail-operator/engprod-269421/contrail-operator-crdsloader",
     tag = "master.latest",
 )
 
 container_push(
-    name = "crdsloader-push",
+    name = "contrail-operator-crdsloader-push",
     format = "Docker",
-    image = ":crdsloader-image",
+    image = ":contrail-operator-crdsloader-image",
     registry = "gcr.io",
-    repository = "engprod-269421/crdsloader",
+    repository = "engprod-269421/contrail-operator-crdsloader",
     tag = "{BUILD_SCM_BRANCH}.{BUILD_SCM_REVISION}",
 )
 
 container_push(
-    name = "crdsloader-push-latest",
+    name = "contrail-operator-crdsloader-push-latest",
     format = "Docker",
-    image = ":crdsloader-image",
+    image = ":contrail-operator-crdsloader-image",
     registry = "gcr.io",
-    repository = "engprod-269421/crdsloader",
+    repository = "engprod-269421/contrail-operator-crdsloader",
     tag = "{BUILD_SCM_BRANCH}.latest",
 )

--- a/deploy/1-create-operator.yaml
+++ b/deploy/1-create-operator.yaml
@@ -195,7 +195,7 @@ spec:
       initContainers:
         - name: init
           # Replace this with the built image name
-          image: registry:5000/contrail-operator/engprod-269421/crdsloader:master.latest
+          image: registry:5000/contrail-operator/engprod-269421/contrail-operator-crdsloader:master.latest
           imagePullPolicy: Always
       containers:
         - name: contrail-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,7 +22,7 @@ spec:
       initContainers:
         - name: init
           # Replace this with the built image name
-          image: registry:5000/contrail-operator/engprod-269421/crdsloader:master.latest
+          image: registry:5000/contrail-operator/engprod-269421/contrail-operator-crdsloader:master.latest
           imagePullPolicy: Always
       containers:
         - name: contrail-operator

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1624,7 +1624,7 @@ func TestManagerController(t *testing.T) {
 				},
 				ServiceConfiguration: contrail.SwiftConfiguration{
 					Containers: []*contrail.Container{
-						{Name: "ringcontroller", Image: "ringcontroller"},
+						{Name: "contrail-operator-ringcontroller", Image: "contrail-operator-ringcontroller"},
 					},
 					SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{
 						AccountBindPort:   6001,
@@ -2338,7 +2338,7 @@ var swift = &contrail.Swift{
 	Spec: contrail.SwiftSpec{
 		ServiceConfiguration: contrail.SwiftConfiguration{
 			Containers: []*contrail.Container{
-				{Name: "ringcontroller", Image: "ringcontroller"},
+				{Name: "contrail-operator-ringcontroller", Image: "contrail-operator-ringcontroller"},
 			},
 			SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{
 				AccountBindPort:   6001,

--- a/pkg/controller/swift/swift_controller_test.go
+++ b/pkg/controller/swift/swift_controller_test.go
@@ -328,7 +328,7 @@ func newSwift(swiftName types.NamespacedName) *contrail.Swift {
 		Spec: contrail.SwiftSpec{
 			ServiceConfiguration: contrail.SwiftConfiguration{
 				Containers: []*contrail.Container{
-					{Name: "ringcontroller", Image: "ringcontroller"},
+					{Name: "contrail-operator-ringcontroller", Image: "contrail-operator-ringcontroller"},
 				},
 				SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{
 					AccountBindPort:   6001,
@@ -420,5 +420,5 @@ func assertJobExists(t *testing.T, fakeClient client.Client, jobName types.Names
 		Namespace: jobName.Namespace,
 	}, job)
 	require.NoError(t, err, "job %v does not exist", jobName)
-	assert.Equal(t, "ringcontroller", job.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "contrail-operator-ringcontroller", job.Spec.Template.Spec.Containers[0].Image)
 }

--- a/pkg/swift/ring/ring.go
+++ b/pkg/swift/ring/ring.go
@@ -101,8 +101,8 @@ func (r *Ring) BuildJob(name types.NamespacedName, nodeSelector map[string]strin
 					ServiceAccountName: r.serviceAccountName,
 					Containers: []core.Container{
 						{
-							Name:            "ringcontroller",
-							Image:           "localhost:5000/contrail-operator/engprod-269421/ringcontroller:master.latest",
+							Name:            "contrail-operator-ringcontroller",
+							Image:           "localhost:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:master.latest",
 							ImagePullPolicy: core.PullAlways,
 							Args:            r.args(),
 						},

--- a/ringcontroller/BUILD.bazel
+++ b/ringcontroller/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
 load("@io_bazel_rules_docker//python:image.bzl", "py_layer")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
-load("@ringcontroller//:requirements.bzl", "all_requirements")
+load("@contrail-operator-ringcontroller//:requirements.bzl", "all_requirements")
 
 py_layer(
     name = "external_deps",
@@ -21,7 +21,7 @@ py_test(
 )
 
 py3_image(
-    name = "ringcontroller",
+    name = "contrail-operator-ringcontroller",
     srcs = [
         "main.py",
         "ring_controller.py",
@@ -34,28 +34,28 @@ py3_image(
 )
 
 container_push(
-    name = "ringcontroller-push",
-    image = ":ringcontroller",
+    name = "contrail-operator-ringcontroller-push",
+    image = ":contrail-operator-ringcontroller",
     format = "Docker",
     registry = "gcr.io",
-    repository = "engprod-269421/ringcontroller",
+    repository = "engprod-269421/contrail-operator-ringcontroller",
     tag = "{BUILD_SCM_BRANCH}.{BUILD_SCM_REVISION}",
 )
 
 container_push(
-    name = "ringcontroller-push-latest",
-    image = ":ringcontroller",
+    name = "contrail-operator-ringcontroller-push-latest",
+    image = ":contrail-operator-ringcontroller",
     format = "Docker",
     registry = "gcr.io",
-    repository = "engprod-269421/ringcontroller",
+    repository = "engprod-269421/contrail-operator-ringcontroller",
     tag = "{BUILD_SCM_BRANCH}.latest",
 )
 
 container_push(
-    name = "ringcontroller-push-local",
-    image = ":ringcontroller",
+    name = "contrail-operator-ringcontroller-push-local",
+    image = ":contrail-operator-ringcontroller",
     format = "Docker",
     registry = "localhost:5000",
-    repository = "contrail-operator/engprod-269421/ringcontroller",
+    repository = "contrail-operator/engprod-269421/contrail-operator-ringcontroller",
     tag = "master.latest",
 )

--- a/ringcontroller/README.md
+++ b/ringcontroller/README.md
@@ -1,5 +1,5 @@
-## Build and push ringcontroller
+## Build and push contrail-operator-ringcontroller
 
 Unfortunately this container cannot be run on Mac OS, since scripts are not ready for cross "compilation". Please use following command from the contrail-operator top directory to build and push image.
 
-    docker run --net host -w /workspace -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace gcr.io/cloud-builders/bazel run //ringcontroller:ringcontroller-push-local
+    docker run --net host -w /workspace -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace gcr.io/cloud-builders/bazel run //ringcontroller:contrail-operator-ringcontroller-push-local

--- a/test/e2e/aio/cluster_test.go
+++ b/test/e2e/aio/cluster_test.go
@@ -90,9 +90,9 @@ func TestCluster(t *testing.T) {
 				manager.Spec.Services.ProvisionManager.Spec.ServiceConfiguration.Containers).Image =
 				"registry:5000/contrail-operator/engprod-269421/contrail-operator-provisioner:" + buildTag
 
-			utils.GetContainerFromList("ringcontroller",
+			utils.GetContainerFromList("contrail-operator-ringcontroller",
 				manager.Spec.Services.Swift.Spec.ServiceConfiguration.Containers).Image =
-				"registry:5000/contrail-operator/engprod-269421/ringcontroller:" + buildTag
+				"registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:" + buildTag
 
 			err = f.Client.Create(context.TODO(), adminPassWordSecret, &test.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 			assert.NoError(t, err)

--- a/test/e2e/aio/command_test.go
+++ b/test/e2e/aio/command_test.go
@@ -231,7 +231,7 @@ func TestCommandServices(t *testing.T) {
 			Spec: contrail.SwiftSpec{
 				ServiceConfiguration: contrail.SwiftConfiguration{
 					Containers: []*contrail.Container{
-						{Name: "ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/ringcontroller:" + buildTag},
+						{Name: "contrail-operator-ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:" + buildTag},
 					},
 					CredentialsSecretName: "commandtest-swift-credentials-secret",
 					SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{

--- a/test/e2e/aio/openstack_test.go
+++ b/test/e2e/aio/openstack_test.go
@@ -199,7 +199,7 @@ func TestOpenstackServices(t *testing.T) {
 				Spec: contrail.SwiftSpec{
 					ServiceConfiguration: contrail.SwiftConfiguration{
 						Containers: []*contrail.Container{
-							{Name: "ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/ringcontroller:" + buildTag},
+							{Name: "contrail-operator-ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:" + buildTag},
 						},
 						CredentialsSecretName: "openstacktest-swift-credentials-secret",
 						SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{

--- a/test/e2e/ha/command_test.go
+++ b/test/e2e/ha/command_test.go
@@ -376,7 +376,7 @@ func getHACommandCluster(namespace, nodeLabel, storagePath string) *contrail.Man
 		Spec: contrail.SwiftSpec{
 			ServiceConfiguration: contrail.SwiftConfiguration{
 				Containers: []*contrail.Container{
-					{Name: "ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/ringcontroller:" + scmBranch + "." + scmRevision},
+					{Name: "contrail-operator-ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:" + scmBranch + "." + scmRevision},
 				},
 				CredentialsSecretName: "swift-pass-secret",
 				SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{

--- a/test/e2e/ha/openstack_services_test.go
+++ b/test/e2e/ha/openstack_services_test.go
@@ -491,7 +491,7 @@ func getHAOpenStackCluster(namespace, nodeLabel string) *contrail.Manager {
 		Spec: contrail.SwiftSpec{
 			ServiceConfiguration: contrail.SwiftConfiguration{
 				Containers: []*contrail.Container{
-					{Name: "ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/ringcontroller:" + scmBranch + "." + scmRevision},
+					{Name: "contrail-operator-ringcontroller", Image: "registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:" + scmBranch + "." + scmRevision},
 				},
 				CredentialsSecretName: "swift-pass-secret",
 				SwiftStorageConfiguration: contrail.SwiftStorageConfiguration{

--- a/test/env/deploy/cluster.yaml
+++ b/test/env/deploy/cluster.yaml
@@ -257,8 +257,8 @@ spec:
         serviceConfiguration:
           credentialsSecretName: "swift-credentials-secret"
           containers:
-            - name: ringcontroller
-              image: registry:5000/contrail-operator/engprod-269421/ringcontroller:master.latest
+            - name: contrail-operator-ringcontroller
+              image: registry:5000/contrail-operator/engprod-269421/contrail-operator-ringcontroller:master.latest
           swiftProxyConfiguration:
             memcachedInstance: "memcached"
             keystoneInstance: "keystone"

--- a/test/env/update_local_registry.sh
+++ b/test/env/update_local_registry.sh
@@ -14,11 +14,11 @@ pull_image()
 while read line; do
 	pull_image svl-artifactory.juniper.net "${line}"
 done <<EOF
-contrail-operator/engprod-269421/ringcontroller:master.latest
+contrail-operator/engprod-269421/contrail-operator-ringcontroller:master.latest
 contrail-operator/engprod-269421/contrail-operator:master.latest
 contrail-operator/engprod-269421/contrail-statusmonitor:master.latest
 contrail-operator/engprod-269421/contrail-operator-provisioner:master.latest
-contrail-operator/engprod-269421/crdsloader:master.latest
+contrail-operator/engprod-269421/contrail-operator-crdsloader:master.latest
 contrail-nightly/contrail-command:master-latest
 contrail-nightly/contrail-controller-config-api:master-latest
 contrail-nightly/contrail-controller-config-devicemgr:master-latest


### PR DESCRIPTION
Rename
crdsloader -> contrail-operator-crdsloader
ringcontroller -> contrail-operator-ringcontroller

This is change is done to make more meaningful and consistent names to new services recently introduced. 