### PR TITLE
Provision manager read hostname from node not from pod's annotations

### DIFF
--- a/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
@@ -189,17 +189,14 @@ func (c *ProvisionManager) UpdateSTS(sts *appsv1.StatefulSet, instanceType strin
 	return UpdateSTS(sts, instanceType, request, reconcileClient, strategy)
 }
 
-func (c *ProvisionManager) getHostnameFromAnnotations(podName string, namespace string, client client.Client) (string, error) {
+func (c *ProvisionManager) getPodsHostname(podName string, namespace string, client client.Client) (string, error) {
 	pod := &corev1.Pod{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: podName, Namespace: namespace}, pod)
 	if err != nil {
 		return "", err
 	}
-	hostname, ok := pod.Annotations["hostname"]
-	if !ok {
-		return "", err
-	}
-	return hostname, nil
+
+	return getPodsHostname(client, pod)
 }
 
 func (c *ProvisionManager) getDataIPFromAnnotations(podName string, namespace string, client client.Client) (string, error) {
@@ -369,7 +366,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 		nodeList := []*ConfigNode{}
 		for _, configService := range configList.Items {
 			for podName, ipAddress := range configService.Status.Nodes {
-				hostname, err := c.getHostnameFromAnnotations(podName, request.Namespace, client)
+				hostname, err := c.getPodsHostname(podName, request.Namespace, client)
 				if err != nil {
 					return err
 				}
@@ -392,7 +389,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 		nodeList := []*AnalyticsNode{}
 		for _, configService := range configList.Items {
 			for podName, ipAddress := range configService.Status.Nodes {
-				hostname, err := c.getHostnameFromAnnotations(podName, request.Namespace, client)
+				hostname, err := c.getPodsHostname(podName, request.Namespace, client)
 				if err != nil {
 					return err
 				}
@@ -418,7 +415,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 		nodeList := []*ControlNode{}
 		for _, controlService := range controlList.Items {
 			for podName, ipAddress := range controlService.Status.Nodes {
-				hostname, err := c.getHostnameFromAnnotations(podName, request.Namespace, client)
+				hostname, err := c.getPodsHostname(podName, request.Namespace, client)
 				if err != nil {
 					return err
 				}
@@ -459,7 +456,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 		nodeList := []*VrouterNode{}
 		for _, vrouterService := range vrouterList.Items {
 			for podName, ipAddress := range vrouterService.Status.Nodes {
-				hostname, err := c.getHostnameFromAnnotations(podName, request.Namespace, client)
+				hostname, err := c.getPodsHostname(podName, request.Namespace, client)
 				if err != nil {
 					return err
 				}
@@ -502,7 +499,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 		databaseNodeList := []DatabaseNode{}
 		for _, db := range cassandras.Items {
 			for podName, ipAddress := range db.Status.Nodes {
-				hostname, err := c.getHostnameFromAnnotations(podName, request.Namespace, client)
+				hostname, err := c.getPodsHostname(podName, request.Namespace, client)
 				if err != nil {
 					return err
 				}

--- a/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
+++ b/pkg/apis/contrail/v1alpha1/provisionmanager_types.go
@@ -191,7 +191,7 @@ func (c *ProvisionManager) UpdateSTS(sts *appsv1.StatefulSet, instanceType strin
 
 func (c *ProvisionManager) getPodsHostname(podName string, namespace string, client client.Client) (string, error) {
 	pod := &corev1.Pod{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: podName, Namespace: namespace}, pod)
+	err := client.Get(context.Background(), types.NamespacedName{Name: podName, Namespace: namespace}, pod)
 	if err != nil {
 		return "", err
 	}
@@ -379,6 +379,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 			}
 			apiPort = configService.Status.Ports.APIPort
 		}
+		sort.SliceStable(nodeList, func(i, j int) bool { return nodeList[i].IPAddress < nodeList[j].IPAddress })
 		nodeYaml, err := yaml.Marshal(nodeList)
 		if err != nil {
 			return err
@@ -400,6 +401,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 				nodeList = append(nodeList, n)
 			}
 		}
+		sort.SliceStable(nodeList, func(i, j int) bool { return nodeList[i].IPAddress < nodeList[j].IPAddress })
 		nodeYaml, err := yaml.Marshal(nodeList)
 		if err != nil {
 			return err
@@ -441,6 +443,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 				nodeList = append(nodeList, n)
 			}
 		}
+		sort.SliceStable(nodeList, func(i, j int) bool { return nodeList[i].IPAddress < nodeList[j].IPAddress })
 		nodeYaml, err := yaml.Marshal(nodeList)
 		if err != nil {
 			return err
@@ -467,6 +470,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 				nodeList = append(nodeList, n)
 			}
 		}
+		sort.SliceStable(nodeList, func(i, j int) bool { return nodeList[i].IPAddress < nodeList[j].IPAddress })
 		nodeYaml, err := yaml.Marshal(nodeList)
 		if err != nil {
 			return err
@@ -510,6 +514,7 @@ func (c *ProvisionManager) InstanceConfiguration(request reconcile.Request,
 				databaseNodeList = append(databaseNodeList, n)
 			}
 		}
+		sort.SliceStable(databaseNodeList, func(i, j int) bool { return databaseNodeList[i].IPAddress < databaseNodeList[j].IPAddress })
 		databaseNodeYaml, err := yaml.Marshal(databaseNodeList)
 		if err != nil {
 			return err


### PR DESCRIPTION
Hostname in pod's annotation might not be immediately available, that cause a situation were a dummy (with empty name) analytics or config nodes were added to vnc-api