### PR TITLE
Change rhel images to ubi images for Openshift manifests

### DIFF
--- a/deploy/openshift/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/00-contrail-09-manager.yaml
@@ -40,19 +40,19 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>-ubi
             - name: api
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>-ubi
             - name: collector
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>-ubi
             - name: devicemanager
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-ubi
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-ubi
               command:
                 - "/bin/sh"
                 - "-c"
@@ -64,11 +64,11 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: schematransformer
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>-ubi
             - name: servicemonitor
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>-ubi
             - name: queryengine
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-ubi
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           logLevel: SYS_DEBUG
@@ -84,13 +84,13 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>-ubi
             - name: dns
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>-ubi
             - name: init
               image: python:3.8.2-alpine
             - name: named
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-ubi
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           zookeeperInstance: zookeeper1
@@ -134,9 +134,9 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: webuijob
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>-ubi
             - name: webuiweb
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>-ubi
     zookeepers:
     - metadata:
         labels:
@@ -170,7 +170,7 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: kubemanager
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-ubi
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           ipFabricForwarding: false
@@ -192,20 +192,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-rhel
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -221,20 +221,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-rhel
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
             - name: multusconfig
               image: busybox:1.31
 
@@ -253,7 +253,7 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -270,6 +270,6 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-rhel
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
             - name: multusconfig
               image: busybox:1.31

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: hub.juniper.net/contrail/contrail-operator:2011.13
+          image: hub.juniper.net/contrail/contrail-operator:2011.31
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
@@ -47,19 +47,19 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: hub.juniper.net/contrail/contrail-analytics-api:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-analytics-api:2011.31-ubi
             - name: api
-              image: hub.juniper.net/contrail/contrail-controller-config-api:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-config-api:2011.31-ubi
             - name: collector
-              image: hub.juniper.net/contrail/contrail-analytics-collector:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-analytics-collector:2011.31-ubi
             - name: devicemanager
-              image: hub.juniper.net/contrail/contrail-controller-config-devicemgr:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-config-devicemgr:2011.31-ubi
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: hub.juniper.net/contrail/contrail-controller-config-dnsmasq:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-config-dnsmasq:2011.31-ubi
               command:
                 - "/bin/sh"
                 - "-c"
@@ -71,13 +71,13 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: schematransformer
-              image: hub.juniper.net/contrail/contrail-controller-config-schema:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-config-schema:2011.31-ubi
             - name: servicemonitor
-              image: hub.juniper.net/contrail/contrail-controller-config-svcmonitor:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-config-svcmonitor:2011.31-ubi
             - name: queryengine
-              image: hub.juniper.net/contrail/contrail-analytics-query-engine:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-analytics-query-engine:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.13
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -95,15 +95,15 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: hub.juniper.net/contrail/contrail-controller-control-control:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-control-control:2011.31-ubi
             - name: dns
-              image: hub.juniper.net/contrail/contrail-controller-control-dns:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-control-dns:2011.31-ubi
             - name: init
               image: python:3.8.2-alpine
             - name: named
-              image: hub.juniper.net/contrail/contrail-controller-control-named:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-control-named:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.13
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -121,7 +121,7 @@ spec:
           - name: init
             image: python:3.8.2-alpine
           - name: provisioner
-            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.13
+            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.31
     rabbitmq:
       metadata:
         labels:
@@ -156,9 +156,9 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: webuijob
-              image: hub.juniper.net/contrail/contrail-controller-webui-job:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-webui-job:2011.31-ubi
             - name: webuiweb
-              image: hub.juniper.net/contrail/contrail-controller-webui-web:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-controller-webui-web:2011.31-ubi
     zookeepers:
     - metadata:
         labels:
@@ -192,9 +192,9 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: kubemanager
-              image: hub.juniper.net/contrail/contrail-kubernetes-kube-manager:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-kubernetes-kube-manager:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.13
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -215,20 +215,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.13-rhel
+          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.31-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail/contrail-node-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-node-init:2011.31-ubi
             - name: vrouteragent
-              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.31-ubi
             - name: vroutercni
-              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.31-ubi
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.31-ubi
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.31-ubi
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -245,19 +245,19 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.13-rhel
+          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.31-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail/contrail-node-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-node-init:2011.31-ubi
             - name: vrouteragent
-              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.31-ubi
             - name: vroutercni
-              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.31-ubi
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.31-ubi
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.13-rhel
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.31-ubi
             - name: multusconfig
               image: busybox:1.31


### PR DESCRIPTION
Because R2011 requires all images to use ubi tab then I change it for Openshift manifests.
I've checked that Openshift dpeloyment works with these tags.