### PR TITLE
Update openshift manifests to support ubi suffix for all images

### DIFF
--- a/deploy/openshift/dev-README.md
+++ b/deploy/openshift/dev-README.md
@@ -30,13 +30,11 @@ For example, If you run cluster on AWS, use e.g. *m5.2xlarge*.
 3. Create configuration file
 Create file with configuration parameters that looks similar to this:
 ```
-CONTRAIL_VERSION=master.1274
+CONTRAIL_VERSION=master.1274-ubi
 CONTRAIL_REGISTRY=hub.juniper.net/contrail-nightly
 DOCKER_CONFIG=example_json_config
 ```
 Under *CONTRAIL_VERSION* field enter proper Contrail container build tag, available in the hub.juniper.net/contrail-nightly registry.
-
-**NOTE** Do not specify the *-rhel* suffix in the build tag, it will be appended automatically where needed.
 
 Choose source registry for container images with *CONTRAIL_REGISTRY* field.
 

--- a/deploy/openshift/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/00-contrail-09-manager.yaml
@@ -40,19 +40,19 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>
             - name: api
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>
             - name: collector
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>
             - name: devicemanager
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>
               command:
                 - "/bin/sh"
                 - "-c"
@@ -64,11 +64,11 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: schematransformer
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>
             - name: servicemonitor
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>
             - name: queryengine
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           logLevel: SYS_DEBUG
@@ -84,13 +84,13 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>
             - name: dns
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>
             - name: init
               image: python:3.8.2-alpine
             - name: named
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           zookeeperInstance: zookeeper1
@@ -134,9 +134,9 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: webuijob
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>
             - name: webuiweb
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>
     zookeepers:
     - metadata:
         labels:
@@ -170,7 +170,7 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: kubemanager
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>
             - name: statusmonitor
               image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           ipFabricForwarding: false
@@ -191,20 +191,20 @@ spec:
             node-role.kubernetes.io/master: ""
         serviceConfiguration:
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -219,20 +219,20 @@ spec:
             node-role.kubernetes.io/worker: ""
         serviceConfiguration:
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: busybox:1.31
 
@@ -251,7 +251,7 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -268,6 +268,6 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: busybox:1.31

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: hub.juniper.net/contrail/contrail-operator:2011.31-ubi
+          image: hub.juniper.net/contrail-nightly/contrail-operator:2011.31-ubi
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: hub.juniper.net/contrail/contrail-operator:2011.31
+          image: hub.juniper.net/contrail/contrail-operator:2011.31-ubi
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
@@ -47,19 +47,19 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: hub.juniper.net/contrail/contrail-analytics-api:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-api:2011.31-ubi
             - name: api
-              image: hub.juniper.net/contrail/contrail-controller-config-api:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-api:2011.31-ubi
             - name: collector
-              image: hub.juniper.net/contrail/contrail-analytics-collector:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-collector:2011.31-ubi
             - name: devicemanager
-              image: hub.juniper.net/contrail/contrail-controller-config-devicemgr:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-devicemgr:2011.31-ubi
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: hub.juniper.net/contrail/contrail-controller-config-dnsmasq:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-dnsmasq:2011.31-ubi
               command:
                 - "/bin/sh"
                 - "-c"
@@ -71,13 +71,13 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: schematransformer
-              image: hub.juniper.net/contrail/contrail-controller-config-schema:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-schema:2011.31-ubi
             - name: servicemonitor
-              image: hub.juniper.net/contrail/contrail-controller-config-svcmonitor:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-config-svcmonitor:2011.31-ubi
             - name: queryengine
-              image: hub.juniper.net/contrail/contrail-analytics-query-engine:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-analytics-query-engine:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.31-ubi
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -95,15 +95,15 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: hub.juniper.net/contrail/contrail-controller-control-control:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-control:2011.31-ubi
             - name: dns
-              image: hub.juniper.net/contrail/contrail-controller-control-dns:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-dns:2011.31-ubi
             - name: init
               image: python:3.8.2-alpine
             - name: named
-              image: hub.juniper.net/contrail/contrail-controller-control-named:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-control-named:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.31-ubi
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -121,7 +121,7 @@ spec:
           - name: init
             image: python:3.8.2-alpine
           - name: provisioner
-            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.31-ubi
+            image: hub.juniper.net/contrail-nightly/contrail-operator-provisioner:2011.31-ubi
     rabbitmq:
       metadata:
         labels:
@@ -156,9 +156,9 @@ spec:
             - name: redis
               image: redis:4.0.2
             - name: webuijob
-              image: hub.juniper.net/contrail/contrail-controller-webui-job:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-job:2011.31-ubi
             - name: webuiweb
-              image: hub.juniper.net/contrail/contrail-controller-webui-web:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-web:2011.31-ubi
     zookeepers:
     - metadata:
         labels:
@@ -192,9 +192,9 @@ spec:
             - name: init
               image: python:3.8.2-alpine
             - name: kubemanager
-              image: hub.juniper.net/contrail/contrail-kubernetes-kube-manager:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-kube-manager:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.31-ubi
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -215,20 +215,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.31-ubi
+          contrailStatusImage: hub.juniper.net/contrail-nightly/contrail-status:2011.31-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail/contrail-node-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:2011.31-ubi
             - name: vrouteragent
-              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:2011.31-ubi
             - name: vroutercni
-              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.31-ubi
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:2011.31-ubi
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:2011.31-ubi
             - name: multusconfig
               image: busybox:1.31
     - metadata:
@@ -245,19 +245,19 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.31-ubi
+          contrailStatusImage: hub.juniper.net/contrail-nightly/contrail-status:2011.31-ubi
           containers:
             - name: init
               image: python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail/contrail-node-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-node-init:2011.31-ubi
             - name: vrouteragent
-              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:2011.31-ubi
             - name: vroutercni
-              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.31-ubi
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:2011.31-ubi
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.31-ubi
+              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:2011.31-ubi
             - name: multusconfig
               image: busybox:1.31

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
@@ -77,7 +77,7 @@ spec:
             - name: queryengine
               image: hub.juniper.net/contrail/contrail-analytics-query-engine:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -103,7 +103,7 @@ spec:
             - name: named
               image: hub.juniper.net/contrail/contrail-controller-control-named:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -121,7 +121,7 @@ spec:
           - name: init
             image: python:3.8.2-alpine
           - name: provisioner
-            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.31
+            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.31-ubi
     rabbitmq:
       metadata:
         labels:
@@ -194,7 +194,7 @@ spec:
             - name: kubemanager
               image: hub.juniper.net/contrail/contrail-kubernetes-kube-manager:2011.31-ubi
             - name: statusmonitor
-              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.31-ubi
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
As from now on all images from this repository will be pushed with -ubi suffix then I update tags for Openshift manifests.
After this change user will have to provide full tag (together with suffix) to properly render manifests