### PR TITLE
Check if no. of failed pods exceeded BackOffLimit

### DIFF
--- a/pkg/controller/command/command_upgrade.go
+++ b/pkg/controller/command/command_upgrade.go
@@ -96,10 +96,10 @@ func (r *ReconcileCommand) checkDataMigrationCompleted(command *contrail.Command
 	err = r.client.Get(context.Background(), jobName, dataMigrationJob)
 	exists := err == nil
 	if exists {
-		if job.Status(dataMigrationJob.Status).JobComplete() {
+		if job.Job(*dataMigrationJob).JobCompleted() {
 			return true, true, nil
 		}
-		if job.Status(dataMigrationJob.Status).JobFailed() {
+		if job.Job(*dataMigrationJob).JobFailed() {
 			return true, false, nil
 		}
 	}

--- a/pkg/controller/swift/swift_controller.go
+++ b/pkg/controller/swift/swift_controller.go
@@ -312,7 +312,7 @@ func (r *ReconcileSwift) removeRingReconcilingJobs(swiftName types.NamespacedNam
 		err := r.client.Get(context.Background(), jobName, ringJob)
 		existingJob := err == nil
 		if existingJob {
-			if job.Status(ringJob.Status).JobPending() {
+			if job.Job(*ringJob).JobPending() {
 				// Wait until job finish executing to avoid breaking the ongoing ring reconciliation
 				return reconcile.Result{
 					Requeue:      true,

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -5,13 +5,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type Status batch.JobStatus
+type Job batch.Job
 
-func (s Status) JobPending() bool {
-	if len(s.Conditions) == 0 {
+func (j Job) JobPending() bool {
+	if len(j.Status.Conditions) == 0 {
 		return true
 	}
-	for _, condition := range s.Conditions {
+	for _, condition := range j.Status.Conditions {
 		if condition.Status == v1.ConditionTrue && (condition.Type == batch.JobComplete || condition.Type == batch.JobFailed) {
 			return false
 		}
@@ -19,11 +19,11 @@ func (s Status) JobPending() bool {
 	return true
 }
 
-func (s Status) JobComplete() bool {
-	if len(s.Conditions) == 0 {
+func (j Job) JobCompleted() bool {
+	if len(j.Status.Conditions) == 0 {
 		return false
 	}
-	for _, condition := range s.Conditions {
+	for _, condition := range j.Status.Conditions {
 		if condition.Status == v1.ConditionTrue && condition.Type == batch.JobComplete {
 			return true
 		}
@@ -31,14 +31,16 @@ func (s Status) JobComplete() bool {
 	return false
 }
 
-func (s Status) JobFailed() bool {
-	if len(s.Conditions) == 0 {
-		return false
-	}
-	for _, condition := range s.Conditions {
+func (j Job) JobFailed() bool {
+	for _, condition := range j.Status.Conditions {
 		if condition.Status == v1.ConditionTrue && condition.Type == batch.JobFailed {
 			return true
 		}
+	}
+	// This is a workaround for k8s bug that Status of Job maybe updated with a delay
+	// and number of pods run can exceed BackOffLimit specified in Job.Spec
+	if j.Spec.BackoffLimit != nil && *j.Spec.BackoffLimit <= j.Status.Failed {
+		return true
 	}
 	return false
 }

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -37,8 +37,8 @@ func (j Job) JobFailed() bool {
 			return true
 		}
 	}
-	// This is a workaround for k8s bug that Status of Job maybe updated with a delay
-	// and number of pods run can exceed BackOffLimit specified in Job.Spec
+	// This is a workaround for k8s bug that Status of Job may be updated with a delay
+	// and number of pods ran can exceed BackOffLimit specified in Job.Spec
 	if j.Spec.BackoffLimit != nil && *j.Spec.BackoffLimit <= j.Status.Failed {
 		return true
 	}

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -12,62 +12,80 @@ import (
 
 func TestStatus_Pending(t *testing.T) {
 	tests := map[string]struct {
-		jobStatus       batch.JobStatus
+		job             batch.Job
 		expectedPending bool
 	}{
 		"no conditions": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{},
+				},
 			},
 			expectedPending: true,
 		},
 		"nil conditions": {
-			jobStatus: batch.JobStatus{
-				Conditions: nil,
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: nil,
+				},
 			},
 			expectedPending: true,
 		},
 		"condition type Failed, status True": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: batch.JobFailed, Status: v1.ConditionTrue}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: batch.JobFailed, Status: v1.ConditionTrue}},
+				},
 			},
 			expectedPending: false,
 		},
 		"condition type Failed, status False": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: batch.JobFailed, Status: v1.ConditionFalse}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: batch.JobFailed, Status: v1.ConditionFalse}},
+				},
 			},
 			expectedPending: true,
 		},
 		"condition type fake, status true": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: "fake", Status: v1.ConditionTrue}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: "fake", Status: v1.ConditionTrue}},
+				},
 			},
 			expectedPending: true,
 		},
 		"condition type fake, status false": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: "fake", Status: v1.ConditionFalse}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: "fake", Status: v1.ConditionFalse}},
+				},
 			},
 			expectedPending: true,
 		},
 		"condition type Complete, status True": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: batch.JobComplete, Status: v1.ConditionTrue}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: batch.JobComplete, Status: v1.ConditionTrue}},
+				},
 			},
 			expectedPending: false,
 		},
 		"condition type Complete, status False": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{{Type: batch.JobComplete, Status: v1.ConditionFalse}},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{{Type: batch.JobComplete, Status: v1.ConditionFalse}},
+				},
 			},
 			expectedPending: true,
 		},
 		"multiple conditions": {
-			jobStatus: batch.JobStatus{
-				Conditions: []batch.JobCondition{
-					{Type: batch.JobComplete, Status: v1.ConditionFalse},
-					{Type: batch.JobFailed, Status: v1.ConditionTrue},
+			job: batch.Job{
+				Status: batch.JobStatus{
+					Conditions: []batch.JobCondition{
+						{Type: batch.JobComplete, Status: v1.ConditionFalse},
+						{Type: batch.JobFailed, Status: v1.ConditionTrue},
+					},
 				},
 			},
 			expectedPending: false,
@@ -76,7 +94,7 @@ func TestStatus_Pending(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// when
-			pending := job.Status(test.jobStatus).JobPending()
+			pending := job.Job(test.job).JobPending()
 			// then
 			assert.Equal(t, test.expectedPending, pending)
 		})


### PR DESCRIPTION
I found that there is a bug in k8s that job-controller responsible for setting Failed Condition on Jobs does not work correctly. Sometimes the Status is not updated or updated with a huge delay. As the result multiple pods are ran and the number of them exceeds the BackOffLimit specified in Job.Spec. 
This bug sometimes causes the failure of nightly job.
This PR contains a workaround that Job is assumed as Failed when it has Failed Condition set to true or the number of failed Pods i equal or greater than BackOffLimit.