### PR TITLE
In CI use local registry name instead of ip address.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node('contrail-operator-node') {
 
             try {
                 sh "kind delete cluster --name=${testEnvPrefix}${ghprbPullId} || true"
-                sh "./test/env/create_k8s_cluster.sh ${testEnvPrefix}${ghprbPullId} ${registry} ${numberOfNodes}"
+                sh 'KIND_CLUSTER_NAME=${testEnvPrefix}${ghprbPullId} NODES=${numberOfNodes} LOCAL_REGISTRY_NAME=proxy_registry ./test/env/create_testenv.sh'
                 sh "kubectl create namespace contrail"
                 waitForUpstreamJob()
                 sh 'BUILD_SCM_REVISION=`echo "${ghprbActualCommit}" | head -c 7` BUILD_SCM_BRANCH=${GIT_BRANCH} E2E_TEST_SUITE=${e2eTestSuite} ./test/env/run_e2e_tests.sh'

--- a/test/env/apply_contrail_cluster.sh
+++ b/test/env/apply_contrail_cluster.sh
@@ -5,6 +5,6 @@ KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
 kubectl apply -f ../../deploy/1-create-operator.yaml
 
-kubectl wait pod --for=condition=Ready --timeout=30s -n contrail -l name=contrail-operator
+kubectl wait deployment --for=condition=available --timeout=240s -n contrail contrail-operator
 kubectl apply -f deploy/secret.yaml
 kubectl apply -f deploy/cluster.yaml

--- a/test/env/create_testenv.sh
+++ b/test/env/create_testenv.sh
@@ -6,12 +6,13 @@ set -o errexit
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 INTERNAL_INSECURE_REGISTRY_PORT="${INTERNAL_INSECURE_REGISTRY_PORT:-5000}"
 NODES="${NODES:-1}"
+LOCAL_REGISTRY_NAME="${LOCAL_REGISTRY_NAME:-kind-registry}"
 
 #create kind network it is used by kind
 docker network inspect kind >/dev/null 2>&1 || \
     docker network create --driver bridge kind
 # create registry container unless it already exists
-reg_name='kind-registry'
+reg_name=${LOCAL_REGISTRY_NAME}
 reg_port=${INTERNAL_INSECURE_REGISTRY_PORT}
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" != 'true' ]; then

--- a/test/env/run_e2e_tests.sh
+++ b/test/env/run_e2e_tests.sh
@@ -29,7 +29,7 @@ else
     TEST_CONFIGURATION="-timeout=45m -test.short"
 fi
 
-kubectl wait pod --for=condition=Ready --timeout=60s -n contrail -l name=contrail-operator
+kubectl wait deployment --for=condition=available --timeout=240s -n contrail contrail-operator
 
 ## Operator-sdk e2e test framework requires namespacedMan and globalMan to be defined, however in our case
 ## all resources and crds are registered before and automatically. That is way empty.yaml files are provided here


### PR DESCRIPTION
Since we are moving to multiple node test environment, a single registry for all nodes will introduce latency.
That is why every worker node will have its own docker registry proxy running as a docker container. Tests scripts will use its name to get its IP inside "kind" docker network, which is used to spawn test clusters.
