### PR TITLE
Use 2011.138 release build in release manifests and remove -ubi suffix

### DIFF
--- a/deploy/openshift/dev-README.md
+++ b/deploy/openshift/dev-README.md
@@ -30,13 +30,18 @@ For example, If you run cluster on AWS, use e.g. *m5.2xlarge*.
 3. Create configuration file
 Create file with configuration parameters that looks similar to this:
 ```
-CONTRAIL_VERSION=master.1274
-CONTRAIL_REGISTRY=hub.juniper.net/contrail-nightly
+contrail_version=master.1460-ubi
+contrail_registry=hub.juniper.net/contrail-nightly
+docker_config=example_json_config
+```
+or
+```
+CONTRAIL_VERSION=2011.138
+CONTRAIL_REGISTRY=hub.juniper.net/contrail
 DOCKER_CONFIG=example_json_config
 ```
-Under *CONTRAIL_VERSION* field enter proper Contrail container build tag, available in the hub.juniper.net/contrail-nightly registry.
 
-**NOTE** Do not specify the *-rhel* suffix in the build tag, it will be appended automatically where needed.
+Under *CONTRAIL_VERSION* field enter proper Contrail container build tag, available in the hub.juniper.net/contrail-nightly registry.
 
 Choose source registry for container images with *CONTRAIL_REGISTRY* field.
 

--- a/deploy/openshift/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: <CONTRAIL_REGISTRY>/contrail-operator:<CONTRAIL_VERSION>-ubi
+          image: <CONTRAIL_REGISTRY>/contrail-operator:<CONTRAIL_VERSION>
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/manifests/00-contrail-09-manager.yaml
@@ -40,19 +40,19 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-api:<CONTRAIL_VERSION>
             - name: api
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-api:<CONTRAIL_VERSION>
             - name: collector
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-collector:<CONTRAIL_VERSION>
             - name: devicemanager
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-devicemgr:<CONTRAIL_VERSION>
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-dnsmasq:<CONTRAIL_VERSION>
               command:
                 - "/bin/sh"
                 - "-c"
@@ -64,13 +64,13 @@ spec:
             - name: redis
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/redis:4.0.2
             - name: schematransformer
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-schema:<CONTRAIL_VERSION>
             - name: servicemonitor
-              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-config-svcmonitor:<CONTRAIL_VERSION>
             - name: queryengine
-              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-analytics-query-engine:<CONTRAIL_VERSION>
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -84,15 +84,15 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-control:<CONTRAIL_VERSION>
             - name: dns
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-dns:<CONTRAIL_VERSION>
             - name: init
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: named
-              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-control-named:<CONTRAIL_VERSION>
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -107,7 +107,7 @@ spec:
           - name: init
             image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/python:3.8.2-alpine
           - name: provisioner
-            image: <CONTRAIL_REGISTRY>/contrail-operator-provisioner:<CONTRAIL_VERSION>-ubi
+            image: <CONTRAIL_REGISTRY>/contrail-operator-provisioner:<CONTRAIL_VERSION>
     rabbitmq:
       metadata:
         labels:
@@ -134,9 +134,9 @@ spec:
             - name: redis
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/redis:4.0.2
             - name: webuijob
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-job:<CONTRAIL_VERSION>
             - name: webuiweb
-              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-controller-webui-web:<CONTRAIL_VERSION>
     zookeepers:
     - metadata:
         labels:
@@ -170,9 +170,9 @@ spec:
             - name: init
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: kubemanager
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-kube-manager:<CONTRAIL_VERSION>
             - name: statusmonitor
-              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-statusmonitor:<CONTRAIL_VERSION>
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -192,20 +192,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>
           containers:
             - name: init
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/busybox:1.31
     - metadata:
@@ -221,20 +221,20 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>-ubi
+          contrailStatusImage: <CONTRAIL_REGISTRY>/contrail-status:<CONTRAIL_VERSION>
           containers:
             - name: init
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: nodeinit
-              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-node-init:<CONTRAIL_VERSION>
             - name: vrouteragent
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-agent:<CONTRAIL_VERSION>
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: vrouterkernelbuildinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-build-init:<CONTRAIL_VERSION>
             - name: vrouterkernelinit
-              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-vrouter-kernel-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/busybox:1.31
 
@@ -253,7 +253,7 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/busybox:1.31
     - metadata:
@@ -270,7 +270,7 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>-ubi
+              image: <CONTRAIL_REGISTRY>/contrail-kubernetes-cni-init:<CONTRAIL_VERSION>
             - name: multusconfig
               image: <CONTRAIL_REGISTRY>/common-docker-third-party/contrail/busybox:1.31
     contrailmonitor:

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: hub.juniper.net/contrail-nightly/contrail-operator:2011.126-ubi
+          image: hub.juniper.net/contrail/contrail-operator:2011.138-ubi
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-08-operator.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: contrail-operator
           # Replace this with the built image name
-          image: hub.juniper.net/contrail/contrail-operator:2011.138-ubi
+          image: hub.juniper.net/contrail/contrail-operator:2011.138
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
+++ b/deploy/openshift/releases/R2011/manifests/00-contrail-09-manager.yaml
@@ -21,11 +21,11 @@ spec:
         serviceConfiguration:
           containers:
             - name: cassandra
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/cassandra:3.11.4
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/cassandra:3.11.4
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: init2
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/cassandra:3.11.4
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/cassandra:3.11.4
     config:
       metadata:
         labels:
@@ -40,37 +40,37 @@ spec:
           analyticsStatisticsTTL: 2
           containers:
             - name: analyticsapi
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-api:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-analytics-api:2011.138
             - name: api
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-api:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-config-api:2011.138
             - name: collector
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-collector:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-analytics-collector:2011.138
             - name: devicemanager
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-devicemgr:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-config-devicemgr:2011.138
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: dnsmasq
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-dnsmasq:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-config-dnsmasq:2011.138
               command:
                 - "/bin/sh"
                 - "-c"
                 - "tail -f /dev/null"
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: init2
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/busybox:1.31
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/busybox:1.31
             - name: redis
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/redis:4.0.2
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/redis:4.0.2
             - name: schematransformer
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-schema:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-config-schema:2011.138
             - name: servicemonitor
-              image: hub.juniper.net/contrail-nightly/contrail-controller-config-svcmonitor:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-config-svcmonitor:2011.138
             - name: queryengine
-              image: hub.juniper.net/contrail-nightly/contrail-analytics-query-engine:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-analytics-query-engine:2011.138
             - name: statusmonitor
-              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.138
           logLevel: SYS_DEBUG
           zookeeperInstance: zookeeper1
     controls:
@@ -84,15 +84,15 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: control
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-control:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-control-control:2011.138
             - name: dns
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-dns:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-control-dns:2011.138
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: named
-              image: hub.juniper.net/contrail-nightly/contrail-controller-control-named:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-control-named:2011.138
             - name: statusmonitor
-              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.138
           zookeeperInstance: zookeeper1
     provisionManager:
       metadata:
@@ -105,9 +105,9 @@ spec:
         serviceConfiguration:
           containers:
           - name: init
-            image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+            image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
           - name: provisioner
-            image: hub.juniper.net/contrail-nightly/contrail-operator-provisioner:2011.126-ubi
+            image: hub.juniper.net/contrail/contrail-operator-provisioner:2011.138
     rabbitmq:
       metadata:
         labels:
@@ -117,9 +117,9 @@ spec:
         serviceConfiguration:
           containers:
           - name: init
-            image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+            image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
           - name: rabbitmq
-            image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/rabbitmq:3.7
+            image: hub.juniper.net/contrail/common-docker-third-party/contrail/rabbitmq:3.7
     webui:
       metadata:
         labels:
@@ -130,13 +130,13 @@ spec:
           cassandraInstance: cassandra1
           containers:
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: redis
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/redis:4.0.2
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/redis:4.0.2
             - name: webuijob
-              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-job:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-webui-job:2011.138
             - name: webuiweb
-              image: hub.juniper.net/contrail-nightly/contrail-controller-webui-web:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-controller-webui-web:2011.138
     zookeepers:
     - metadata:
         labels:
@@ -152,11 +152,11 @@ spec:
         serviceConfiguration:
           containers:
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: conf-init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: zookeeper
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/zookeeper:3.5.5
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/zookeeper:3.5.5
     kubemanagers:
     - metadata:
         labels:
@@ -168,11 +168,11 @@ spec:
           zookeeperInstance: zookeeper1
           containers:
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: kubemanager
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-kube-manager:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-kubernetes-kube-manager:2011.138
             - name: statusmonitor
-              image: hub.juniper.net/contrail-nightly/contrail-statusmonitor:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-statusmonitor:2011.138
           ipFabricForwarding: false
           ipFabricSnat: true
           kubernetesTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -192,22 +192,22 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail-nightly/contrail-status:2011.126-ubi
+          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.138
           containers:
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-node-init:2011.138
             - name: vrouteragent
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.138
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.138
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.138
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.138
             - name: multusconfig
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/busybox:1.31
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/busybox:1.31
     - metadata:
         labels:
           contrail_cluster: cluster1
@@ -221,22 +221,22 @@ spec:
         serviceConfiguration:
           cassandraInstance: cassandra1
           controlInstance: control1
-          contrailStatusImage: hub.juniper.net/contrail-nightly/contrail-status:2011.126-ubi
+          contrailStatusImage: hub.juniper.net/contrail/contrail-status:2011.138
           containers:
             - name: init
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/python:3.8.2-alpine
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/python:3.8.2-alpine
             - name: nodeinit
-              image: hub.juniper.net/contrail-nightly/contrail-node-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-node-init:2011.138
             - name: vrouteragent
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-agent:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-agent:2011.138
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.138
             - name: vrouterkernelbuildinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-build-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-build-init:2011.138
             - name: vrouterkernelinit
-              image: hub.juniper.net/contrail-nightly/contrail-vrouter-kernel-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-vrouter-kernel-init:2011.138
             - name: multusconfig
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/busybox:1.31
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/busybox:1.31
     contrailCNIs:
     - metadata:
         labels:
@@ -252,9 +252,9 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.138
             - name: multusconfig
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/busybox:1.31
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/busybox:1.31
     - metadata:
         labels:
           contrail_cluster: cluster1
@@ -269,9 +269,9 @@ spec:
           controlInstance: control1
           containers:
             - name: vroutercni
-              image: hub.juniper.net/contrail-nightly/contrail-kubernetes-cni-init:2011.126-ubi
+              image: hub.juniper.net/contrail/contrail-kubernetes-cni-init:2011.138
             - name: multusconfig
-              image: hub.juniper.net/contrail-nightly/common-docker-third-party/contrail/busybox:1.31
+              image: hub.juniper.net/contrail/common-docker-third-party/contrail/busybox:1.31
     contrailmonitor:
       metadata:
         labels:


### PR DESCRIPTION
Use 2011.138 release build in release manifests and remove -ubi suffix from the template manifests