### PR TITLE
adding node_timeout to 90 sec, it was missing  in swift proxy, openstack has default value of 10.

### DIFF
--- a/pkg/controller/swiftproxy/swiftproxy_config.go
+++ b/pkg/controller/swiftproxy/swiftproxy_config.go
@@ -79,6 +79,7 @@ pipeline = catch_errors gatekeeper healthcheck cache container_sync bulk tempurl
 use = egg:swift#proxy
 allow_account_management = true
 account_autocreate = true
+node_timeout = 90
 
 [filter:tempurl]
 use = egg:swift#tempurl

--- a/pkg/controller/swiftproxy/swiftproxy_controller_test.go
+++ b/pkg/controller/swiftproxy/swiftproxy_controller_test.go
@@ -725,6 +725,7 @@ pipeline = catch_errors gatekeeper healthcheck cache container_sync bulk tempurl
 use = egg:swift#proxy
 allow_account_management = true
 account_autocreate = true
+node_timeout = 90
 
 [filter:tempurl]
 use = egg:swift#tempurl


### PR DESCRIPTION
adding node_timeout to 90 sec, inwas missing  in swift proxy